### PR TITLE
Ct/eslinting fixes 2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,26 +1,32 @@
 module.exports = {
   root: true,
   env: {
-    'browser': true,
-    'node': true,
-    'es6': true,
-    'jest': true
+    browser: true,
+    node: true,
+    es6: true,
+    jest: true
   },
   extends: [
-    'eslint:recommended'
+    'standard-with-typescript'
   ],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: [
+    '@typescript-eslint'
+  ],
   parserOptions: {
+    project: './tsconfig.json',
     ecmaVersion: 'latest',
-    sourceType: 'module',
+    sourceType: 'module'
   },
-  ignorePatterns: ['src/public/static/vue3.js'],
+  ignorePatterns: [
+    '.eslintrc.js',
+    'jest.config.js'
+  ],
   rules: {
-    quotes: ['error', 'single', { 'avoidEscape': true }],
-    'semi': [2, 'always'],
+    '@typescript-eslint/explicit-function-return-type': 'off', // TODO: remove later
+    '@typescript-eslint/no-unsafe-argument': ['off'], // TODO: remove later
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-unused-vars': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
   }
-};
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,8 +23,9 @@ module.exports = {
     'jest.config.js'
   ],
   rules: {
-    '@typescript-eslint/explicit-function-return-type': 'off', // TODO: remove later
-    '@typescript-eslint/no-unsafe-argument': ['off'], // TODO: remove later
+    '@typescript-eslint/explicit-function-return-type': 'off', // TODO: remove and fix later
+    '@typescript-eslint/no-unsafe-argument': ['off'], // TODO: remove and fix later
+    '@typescript-eslint/no-non-null-assertion': 'off', // TODO: remove and fix later
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-unused-vars': process.env.NODE_ENV === 'production' ? 'warn' : 'off',

--- a/server/__tests__/index.test.js
+++ b/server/__tests__/index.test.js
@@ -1,38 +1,38 @@
-// import { get } from 'axios';
-const axios = require('axios');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const axios = require('axios')
 
-jest.mock('axios');
-const baseUrl = 'http://127.0.0.1:8080/';
+jest.mock('axios')
+const baseUrl = 'http://127.0.0.1:8080/'
 
 beforeAll(() => {
-  jest.mock('axios');
-});
+  jest.mock('axios')
+})
 
 describe('Test Routes', () => {
   test('Default route', async () => {
     axios.get = jest.fn().mockResolvedValue({
       status: 200,
       data: '<!DOCTYPE html><html lang="en"><body>Website created using create-react-app</body></html>'
-    });
+    })
 
-    const res = await axios.get(`${baseUrl}`);
+    const res = await axios.get(`${baseUrl}`)
 
-    expect(res).toBeTruthy();
-    expect(res.status).toBe(200);
-    expect(res.data).toContain('<!DOCTYPE html>');
-    expect(res.data).toContain('Website created using create-react-app');
-  });
+    expect(res).toBeTruthy()
+    expect(res.status).toBe(200)
+    expect(res.data).toContain('<!DOCTYPE html>')
+    expect(res.data).toContain('Website created using create-react-app')
+  })
 
   test('PING route', async () => {
     axios.get = jest.fn().mockResolvedValue({
       status: 200,
       data: 'ok'
-    });
+    })
 
-    const res = await axios.get(`${baseUrl}ping`);
+    const res = await axios.get(`${baseUrl}ping`)
 
-    expect(res).toBeTruthy();
-    expect(res.status).toBe(200);
-    expect(res.data).toEqual('ok');
-  });
-});
+    expect(res).toBeTruthy()
+    expect(res.status).toBe(200)
+    expect(res.data).toEqual('ok')
+  })
+})

--- a/server/config.js
+++ b/server/config.js
@@ -1,9 +1,9 @@
-const processEnv = {};
-const envs = { ...process.env, ...process.client_envs };
+const processEnv = {}
+const envs = { ...process.env, ...process.client_envs }
 
 Object.keys(envs).forEach((k) => {
-  processEnv[k.toUpperCase()] = envs[k];
-});
+  processEnv[k.toUpperCase()] = envs[k]
+})
 
 const config = {
   AuthServiceEndpoint: 'https://login.universalconnectproject.org/api',
@@ -36,12 +36,12 @@ const config = {
   UcpAuthClientSecret: '',
   UcpAuthEncryptionKey: ''
 
-};
-
-const arr = Object.keys(config);
-for (let i = 0; i < arr.length; i++) {
-  const key = arr[i];
-  config[key] = processEnv[key.toUpperCase()] || config[key];
 }
 
-module.exports = config;
+const arr = Object.keys(config)
+for (let i = 0; i < arr.length; i++) {
+  const key = arr[i]
+  config[key] = processEnv[key.toUpperCase()] || config[key]
+}
+
+module.exports = config

--- a/server/connect/__tests__/connectApiExpess-tests.js
+++ b/server/connect/__tests__/connectApiExpess-tests.js
@@ -1,10 +1,10 @@
 describe('Test Connect Routes', () => {
   test('Test sendAnalyticsEvent route', async () => {
     // TODO: Figure out error with mock
-    expect(true).toBe(true);
+    expect(true).toBe(true)
     // const res = mocked.get('sendAnalyticsEvent', () => 'ok');
     //
     // expect(res).toBeTruthy();
     // expect(res.status).toBe(200);
-  });
-});
+  })
+})

--- a/server/connect/apiStubs.js
+++ b/server/connect/apiStubs.js
@@ -1,32 +1,32 @@
-const fs = require('fs');
-const { ApiEndpoints } = require('../../shared/connect/ApiEndpoint.js');
+const fs = require('fs')
+const { ApiEndpoints } = require('../../shared/connect/ApiEndpoint.js')
 
 module.exports = function (app) {
   app.get('/jobs/:guid', async (req, res) => {
-    res.sendFile(__dirname + '/stubs/job.json');
-  });
+    res.sendFile(__dirname + '/stubs/job.json')
+  })
   app.post(ApiEndpoints.MEMBERS, async (req, res) => {
-    res.sendFile(__dirname + '/stubs/member.json');
-  });
+    res.sendFile(__dirname + '/stubs/member.json')
+  })
   app.put(`${ApiEndpoints.MEMBERS}/:member_guid`, async (req, res) => {
-    res.sendFile(__dirname + '/stubs/member.json');
-  });
+    res.sendFile(__dirname + '/stubs/member.json')
+  })
   app.get(ApiEndpoints.MEMBERS, async (req, res) => {
-    res.sendFile(__dirname + '/stubs/members.json');
-  });
+    res.sendFile(__dirname + '/stubs/members.json')
+  })
   app.get(`${ApiEndpoints.MEMBERS}/:member_guid`, async (req, res) => {
-    res.sendFile(__dirname + '/stubs/member.json');
-  });
+    res.sendFile(__dirname + '/stubs/member.json')
+  })
   app.delete(`${ApiEndpoints.MEMBERS}/:member_guid`, async (req, res) => {
-    res.sendFile(__dirname + '/stubs/member.json');
-  });
+    res.sendFile(__dirname + '/stubs/member.json')
+  })
   app.get(`${ApiEndpoints.MEMBERS}/:member_guid/credentials`, async (req, res) => {
-    const ret = await req.connectService.getMemberCredentials(req.params.member_guid);
-    res.send(ret);
-  });
+    const ret = await req.connectService.getMemberCredentials(req.params.member_guid)
+    res.send(ret)
+  })
   app.get(`${ApiEndpoints.INSTITUTIONS}/:institution_guid/credentials`, async (req, res) => {
-    res.sendFile(__dirname + '/stubs/credentials.json');
-  });
+    res.sendFile(__dirname + '/stubs/credentials.json')
+  })
   // app.get(ApiEndpoints.INSTITUTIONS, async (req, res) => {
   //   res.sendFile(__dirname + '/stubs/institutions.json')
   // })
@@ -39,4 +39,4 @@ module.exports = function (app) {
   // app.get(`${ApiEndpoints.INSTITUTIONS}/:institution_guid`, async (req, res) => {
   //   res.sendFile(__dirname + '/stubs/institution.json')
   // })
-};
+}

--- a/server/connect/connectApiExpress.js
+++ b/server/connect/connectApiExpress.js
@@ -1,93 +1,93 @@
-import { ConnectApi } from './connectApi';
-import * as path from 'path';
-const { instrumentation } = require('../providers');
-const { contextHandler } = require('../infra/context.ts');
-const { ApiEndpoints } = require('../../shared/connect/ApiEndpoint.js');
-const {ConnectionStatus} = require('../../shared/contract.ts');
-const stubs = require('./instrumentations.js');
-const config = require('../config');
-const logger = require('../infra/logger');
-const http = require('../infra/http');
-const { readFile } = require('../utils/fs');
+import { ConnectApi } from './connectApi'
+import * as path from 'path'
+const { instrumentation } = require('../providers')
+const { contextHandler } = require('../infra/context.ts')
+const { ApiEndpoints } = require('../../shared/connect/ApiEndpoint.js')
+const { ConnectionStatus } = require('../../shared/contract.ts')
+const stubs = require('./instrumentations.js')
+const config = require('../config')
+const logger = require('../infra/logger')
+const http = require('../infra/http')
+const { readFile } = require('../utils/fs')
 
 module.exports = function (app) {
-  stubs(app);
-  app.use(contextHandler);
+  stubs(app)
+  app.use(contextHandler)
   app.use(async (req, res, next) => {
-    if (req.path === '/' || req.path.startsWith('/example') || req.path.startsWith('/static')) return next();
-    req.connectService = new ConnectApi(req);
+    if (req.path === '/' || req.path.startsWith('/example') || req.path.startsWith('/static')) return next()
+    req.connectService = new ConnectApi(req)
     if (await req.connectService.init()) {
       if (!req.context.resolved_user_id) {
-        req.context.resolved_user_id = await req.connectService.ResolveUserId(req.context.user_id);
+        req.context.resolved_user_id = await req.connectService.ResolveUserId(req.context.user_id)
       }
     }
-    next();
-  });
+    next()
+  })
 
   app.post('/analytics*', async (req, res) => {
     if (config.AnalyticsServiceEndpoint) {
-      const ret = await req.connectService.analytics(req.path, req.body);
-      res.send(ret);
+      const ret = await req.connectService.analytics(req.path, req.body)
+      res.send(ret)
     } else {
-      res.send(require('./stubs/analytics_sessions.js'));
+      res.send(require('./stubs/analytics_sessions.js'))
     }
-  });
+  })
 
   app.post(ApiEndpoints.MEMBERS, async (req, res) => {
     // res.send(require('./stubs/member.js'))
     // return;
-    const ret = await req.connectService.addMember(req.body);
-    res.send(ret);
-  });
+    const ret = await req.connectService.addMember(req.body)
+    res.send(ret)
+  })
   app.put(`${ApiEndpoints.MEMBERS}/:member_guid`, async (req, res) => {
     // res.send(require('./stubs/member.js'))
     // return;
-    const ret = await req.connectService.updateMember(req.body);
-    res.send(ret);
-  });
+    const ret = await req.connectService.updateMember(req.body)
+    res.send(ret)
+  })
   app.get(`${ApiEndpoints.MEMBERS}/:member_guid/`, async (req, res) => {
     // res.send(require('./stubs/member.js'))
     // return;
-    const ret = await req.connectService.loadMemberByGuid(req.params.member_guid);
-    res.send(ret);
+    const ret = await req.connectService.loadMemberByGuid(req.params.member_guid)
+    res.send(ret)
     // res.sendFile(__dirname + '/stubs/member.json')
-  });
+  })
   app.get(`${ApiEndpoints.MEMBERS}/:member_guid/credentials`, async (req, res) => {
     // res.send(require('./stubs/member_credentials.js'))
     // return;
-    const ret = await req.connectService.getMemberCredentials(req.params.member_guid);
-    res.send(ret);
-  });
+    const ret = await req.connectService.getMemberCredentials(req.params.member_guid)
+    res.send(ret)
+  })
   app.get(`${ApiEndpoints.MEMBERS}/:member_guid/oauth_window_uri`, async (req, res) => {
-    const ret = await req.connectService.getOauthWindowUri(req.params.member_guid);
-    res.send({ oauth_window_uri: ret });
+    const ret = await req.connectService.getOauthWindowUri(req.params.member_guid)
+    res.send({ oauth_window_uri: ret })
     // res.sendFile(__dirname + '/stubs/member.json')
-  });
+  })
   app.delete(`${ApiEndpoints.MEMBERS}/:member_guid`, async (req, res) => {
-    res.sendFile(__dirname + '/stubs/member.json');
+    res.sendFile(__dirname + '/stubs/member.json')
     // let ret = await req.connectService.deleteMember(req.params.member_guid)
     // res.send(ret)
-  });
+  })
   app.get(`${ApiEndpoints.INSTITUTIONS}/:institution_guid/credentials`, async (req, res) => {
-    const credentials = await req.connectService.getInstitutionCredentials(req.params.institution_guid);
-    res.send(credentials);
-  });
+    const credentials = await req.connectService.getInstitutionCredentials(req.params.institution_guid)
+    res.send(credentials)
+  })
   app.get(`${ApiEndpoints.INSTITUTIONS}/favorite`, async (req, res) => {
-    const ret = await req.connectService.loadPopularInstitutions();
-    res.send(ret);
-  });
+    const ret = await req.connectService.loadPopularInstitutions()
+    res.send(ret)
+  })
   app.get(`${ApiEndpoints.INSTITUTIONS}/discovered`, async (req, res) => {
-    const ret = await req.connectService.loadDiscoveredInstitutions();
-    res.send(ret);
-  });
+    const ret = await req.connectService.loadDiscoveredInstitutions()
+    res.send(ret)
+  })
   app.get(`${ApiEndpoints.INSTITUTIONS}/:institution_guid`, async (req, res) => {
-    const ret = await req.connectService.loadInstitutionByGuid(req.params.institution_guid);
-    res.send(ret);
-  });
+    const ret = await req.connectService.loadInstitutionByGuid(req.params.institution_guid)
+    res.send(ret)
+  })
   app.get(ApiEndpoints.INSTITUTIONS, async (req, res) => {
-    const ret = await req.connectService.loadInstitutions(req.query.search_name || req.query.routing_number);
-    res.send(ret);
-  });
+    const ret = await req.connectService.loadInstitutions(req.query.search_name || req.query.routing_number)
+    res.send(ret)
+  })
   app.get('/jobs/:guid', async (req, res) => {
     // this doesn't seem to affect anything as long as there is a response
     res.send({
@@ -95,75 +95,75 @@ module.exports = function (app) {
         guid: req.params.guid,
         job_type: 0 // must
       }
-    });
-  });
+    })
+  })
 
   app.get('/oauth_states', async (req, res) => {
-    const ret = await req.connectService.getOauthStates(req.query.outbound_member_guid);
-    res.send(ret);
-  });
+    const ret = await req.connectService.getOauthStates(req.query.outbound_member_guid)
+    res.send(ret)
+  })
 
   app.get('/oauth_states/:guid', async (req, res) => {
-    const ret = await req.connectService.getOauthState(req.params.guid);
-    res.send(ret);
-  });
+    const ret = await req.connectService.getOauthState(req.params.guid)
+    res.send(ret)
+  })
 
   app.get(ApiEndpoints.MEMBERS, async (req, res) => {
-    const ret = await req.connectService.loadMembers();
+    const ret = await req.connectService.loadMembers()
     res.send({
       members: ret
-    });
-  });
+    })
+  })
 
   app.post(ApiEndpoints.INSTRUMENTATION, async (req, res) => {
     if (await instrumentation(req.context, req.body.instrumentation)) {
-      res.sendStatus(200);
-      return;
+      res.sendStatus(200)
+      return
     }
-    res.sendStatus(400);
-  });
+    res.sendStatus(400)
+  })
 
   app.post('/members/:member_guid/unthrottled_aggregate', async (req, res) => {
-    res.send({ member: { job_guid: 'JOB-179e7c31-53d6-4cfb-b95d-6b2686d1b817', status: 8 } }); // RECONNECTED?
+    res.send({ member: { job_guid: 'JOB-179e7c31-53d6-4cfb-b95d-6b2686d1b817', status: 8 } }) // RECONNECTED?
 
     // let ret = await req.connectService.updateMember(req.body);
     // res.send(ret)
-  });
+  })
 
   app.all('/webhook/:provider/*', async function (req, res) {
-    const { provider } = req.params;
-    logger.info(`received web hook at: ${req.path}`, req.query);
+    const { provider } = req.params
+    logger.info(`received web hook at: ${req.path}`, req.query)
     // console.log(req.body)
-    const ret = await ConnectApi.handleOauthResponse(provider, req.params, req.query, req.body);
-    res.send(ret);
-  });
+    const ret = await ConnectApi.handleOauthResponse(provider, req.params, req.query, req.body)
+    res.send(ret)
+  })
 
   app.get('/oauth/:provider/redirect_from/', async (req, res) => {
-    const { member_guid, error_reason } = req.query;
-    const { provider } = req.params;
-    const ret = await ConnectApi.handleOauthResponse(provider, req.params, req.query);
-    const metadata = JSON.stringify({ member_guid, error_reason });
-    const app_url = `mx://oauth_complete?metadata=${encodeURIComponent(metadata)}`;
+    const { member_guid, error_reason } = req.query
+    const { provider } = req.params
+    const ret = await ConnectApi.handleOauthResponse(provider, req.params, req.query)
+    const metadata = JSON.stringify({ member_guid, error_reason })
+    const app_url = `mx://oauth_complete?metadata=${encodeURIComponent(metadata)}`
     const queries = {
       status: ret?.status === ConnectionStatus.CONNECTED ? 'success' : 'error',
       app_url,
       redirect: 'true',
       error_reason,
       member_guid: ret?.id
-    };
+    }
 
-    const oauthParams = new RegExp(Object.keys(queries).map(r => `\\$${r}`).join('|'), 'g');
+    const oauthParams = new RegExp(Object.keys(queries).map(r => `\\$${r}`).join('|'), 'g')
     function mapOauthParams (queries, res, html) {
-      res.send(html.replaceAll(oauthParams, q => queries[q.substring(1)] || ''));
+      res.send(html.replaceAll(oauthParams, q => queries[q.substring(1)] || ''))
     }
 
     if (config.ResourcePrefix !== 'local') {
-      const resourcePath = `${config.ResourcePrefix}${config.ResourceVersion}/oauth/success.html`;
-      http.wget(resourcePath).then(html => { mapOauthParams(queries, res, html); });
+      const resourcePath = `${config.ResourcePrefix}${config.ResourceVersion}/oauth/success.html`
+      http.wget(resourcePath).then(html => { mapOauthParams(queries, res, html) })
     } else {
-      const filePath = path.join(__dirname, '../', 'build', 'oauth/success.html');
-      const html = await readFile(filePath);
-      mapOauthParams(queries, res, html);
+      const filePath = path.join(__dirname, '../', 'build', 'oauth/success.html')
+      const html = await readFile(filePath)
+      mapOauthParams(queries, res, html)
     }
-  });
-};
+  })
+}

--- a/server/connect/instrumentations.js
+++ b/server/connect/instrumentations.js
@@ -1,26 +1,26 @@
-const fs = require('fs');
-const { ApiEndpoints } = require('../../shared/connect/ApiEndpoint.js');
+const fs = require('fs')
+const { ApiEndpoints } = require('../../shared/connect/ApiEndpoint.js')
 
 module.exports = function (app) {
   app.post('/feature_visits', async (req, res) => {
-    res.sendStatus(200);
-  });
+    res.sendStatus(200)
+  })
   app.get(ApiEndpoints.AGREEMENT, async (req, res) => {
-    res.send('');
-  });
+    res.send('')
+  })
   app.get('/offers/*', async (req, res) => {
-    res.send('');
-  });
+    res.send('')
+  })
   app.get(ApiEndpoints.USER_FEATURES, async (req, res) => {
-    res.send(require('./stubs/user_features.js'));
-  });
+    res.send(require('./stubs/user_features.js'))
+  })
   app.get(ApiEndpoints.TRANSACTION_RULES, async (req, res) => {
-    res.send(require('./stubs/transaction_rules.js'));
-  });
+    res.send(require('./stubs/transaction_rules.js'))
+  })
   app.get('/raja/data', async (req, res) => {
-    res.send(require('./stubs/data_master.js'));
-  });
+    res.send(require('./stubs/data_master.js'))
+  })
   app.get('/raja/extend_session', async (req, res) => {
-    res.sendStatus(200);
-  });
-};
+    res.sendStatus(200)
+  })
+}

--- a/server/connect/stubs/akoya/accounts.js
+++ b/server/connect/stubs/akoya/accounts.js
@@ -27,4 +27,4 @@ module.exports = {
       }
     }
   ]
-};
+}

--- a/server/connect/stubs/analytics_sessions.js
+++ b/server/connect/stubs/analytics_sessions.js
@@ -7,4 +7,4 @@ module.exports = {
     product_name: 'Individual Widget',
     product_version: '1.0.0'
   }
-};
+}

--- a/server/connect/stubs/challenges/image.js
+++ b/server/connect/stubs/challenges/image.js
@@ -111,4 +111,4 @@ module.exports = {
     tax_statement_is_enabled: false,
     successfully_aggregated_at: null
   }
-};
+}

--- a/server/connect/stubs/challenges/options.js
+++ b/server/connect/stubs/challenges/options.js
@@ -295,4 +295,4 @@ module.exports = {
     tax_statement_is_enabled: false,
     successfully_aggregated_at: null
   }
-};
+}

--- a/server/connect/stubs/challenges/question.js
+++ b/server/connect/stubs/challenges/question.js
@@ -111,4 +111,4 @@ module.exports = {
     tax_statement_is_enabled: false,
     successfully_aggregated_at: null
   }
-};
+}

--- a/server/connect/stubs/challenges/securityCode.js
+++ b/server/connect/stubs/challenges/securityCode.js
@@ -23,4 +23,4 @@ module.exports = {
     }
     ]
   }
-};
+}

--- a/server/connect/stubs/credentials.js
+++ b/server/connect/stubs/credentials.js
@@ -23,4 +23,4 @@ module.exports = {
     total_entries: 2,
     total_pages: 1
   }
-};
+}

--- a/server/connect/stubs/data_master.js
+++ b/server/connect/stubs/data_master.js
@@ -134,4 +134,4 @@ module.exports = {
   address: {
     bullseye: 'http://localhost:3001'
   }
-};
+}

--- a/server/connect/stubs/discovered.js
+++ b/server/connect/stubs/discovered.js
@@ -14,4 +14,4 @@ module.exports = [
     supports_transaction_history: true,
     url: 'https://gringotts.qa.internal.mx/'
   }
-];
+]

--- a/server/connect/stubs/favorite.js
+++ b/server/connect/stubs/favorite.js
@@ -14,4 +14,4 @@ module.exports = [
     supports_transaction_history: true,
     url: 'https://gringotts.qa.internal.mx/'
   }
-];
+]

--- a/server/connect/stubs/finicity/accounts.js
+++ b/server/connect/stubs/finicity/accounts.js
@@ -107,4 +107,4 @@ module.exports = {
     marketSegment: 'personal'
   }
   ]
-};
+}

--- a/server/connect/stubs/finicity/transactions.js
+++ b/server/connect/stubs/finicity/transactions.js
@@ -36,4 +36,4 @@ module.exports = {
       optionSharesPerContract: 0
     }
   ]
-};
+}

--- a/server/connect/stubs/finicity/webhooks/added.js
+++ b/server/connect/stubs/finicity/webhooks/added.js
@@ -87,4 +87,4 @@ module.exports = {
       oauth: true
     }
   }
-};
+}

--- a/server/connect/stubs/finicity/webhooks/adding.js
+++ b/server/connect/stubs/finicity/webhooks/adding.js
@@ -29,4 +29,4 @@ module.exports = {
       oauth: true
     }
   }
-};
+}

--- a/server/connect/stubs/finicity/webhooks/done.js
+++ b/server/connect/stubs/finicity/webhooks/done.js
@@ -26,4 +26,4 @@ module.exports = {
     eventId: '1688829095490-47a556ac5d61cf3ad20e10c6',
     payload: {}
   }
-};
+}

--- a/server/connect/stubs/finicity/webhooks/institutionSupported.js
+++ b/server/connect/stubs/finicity/webhooks/institutionSupported.js
@@ -28,4 +28,4 @@ module.exports = {
       institutionId: '102176'
     }
   }
-};
+}

--- a/server/connect/stubs/finicity/webhooks/ping.js
+++ b/server/connect/stubs/finicity/webhooks/ping.js
@@ -24,4 +24,4 @@ module.exports = {
     eventType: 'ping',
     payload: {}
   }
-};
+}

--- a/server/connect/stubs/finicity/webhooks/processing.js
+++ b/server/connect/stubs/finicity/webhooks/processing.js
@@ -28,4 +28,4 @@ module.exports = {
       institutionId: '102176'
     }
   }
-};
+}

--- a/server/connect/stubs/finicity/webhooks/started.js
+++ b/server/connect/stubs/finicity/webhooks/started.js
@@ -26,4 +26,4 @@ module.exports = {
     eventId: '1688829063731-09493ef4b934040cc17b18c4',
     payload: {}
   }
-};
+}

--- a/server/connect/stubs/institution.js
+++ b/server/connect/stubs/institution.js
@@ -47,4 +47,4 @@ module.exports = {
       }
     ]
   }
-};
+}

--- a/server/connect/stubs/institutions.js
+++ b/server/connect/stubs/institutions.js
@@ -16,4 +16,4 @@ module.exports = {
       url: 'https://gringotts.qa.internal.mx/'
     }
   ]
-};
+}

--- a/server/connect/stubs/instrumentation.js
+++ b/server/connect/stubs/instrumentation.js
@@ -1,1 +1,1 @@
-module.exports = {};
+module.exports = {}

--- a/server/connect/stubs/job.js
+++ b/server/connect/stubs/job.js
@@ -12,4 +12,4 @@ module.exports = {
     started_at: 1680125637,
     updated_at: 1680125639
   }
-};
+}

--- a/server/connect/stubs/member.js
+++ b/server/connect/stubs/member.js
@@ -12,4 +12,4 @@ module.exports = {
       steps: []
     }
   }
-};
+}

--- a/server/connect/stubs/member_credentials.js
+++ b/server/connect/stubs/member_credentials.js
@@ -19,4 +19,4 @@ module.exports = {
     options: null
   }
   ]
-};
+}

--- a/server/connect/stubs/members.js
+++ b/server/connect/stubs/members.js
@@ -17,4 +17,4 @@ module.exports = {
       connection_status: 'CONNECTED'
     }
   ]
-};
+}

--- a/server/connect/stubs/oauth_state.js
+++ b/server/connect/stubs/oauth_state.js
@@ -10,4 +10,4 @@ module.exports = {
     updated_at: '2023-03-31T21:08:39+00:00',
     user_guid: 'USR-241266ed-803a-4841-8a8a-0f37551e8f56'
   }
-};
+}

--- a/server/connect/stubs/oauth_states.js
+++ b/server/connect/stubs/oauth_states.js
@@ -34,4 +34,4 @@ module.exports = {
       user_guid: 'USR-241266ed-803a-4841-8a8a-0f37551e8f56'
     }
   ]
-};
+}

--- a/server/connect/stubs/transaction_rules.js
+++ b/server/connect/stubs/transaction_rules.js
@@ -1,1 +1,1 @@
-module.exports = { transaction_rules: [] };
+module.exports = { transaction_rules: [] }

--- a/server/connect/stubs/user_features.js
+++ b/server/connect/stubs/user_features.js
@@ -71,4 +71,4 @@ module.exports = {
       updated_at: '2023-02-10T19:22:59.000Z'
     }
   ]
-};
+}

--- a/server/incubationVcs/vcsService.ts
+++ b/server/incubationVcs/vcsService.ts
@@ -1,20 +1,20 @@
 import {
   type Institution
-} from '../../shared/contract';
-import * as config from '../config';
-import * as logger from '../infra/logger';
+} from '../../shared/contract'
+import * as config from '../config'
+import * as logger from '../infra/logger'
 
-import { ProviderApiBase } from '../providers';
+import { ProviderApiBase } from '../providers'
 
 export class VcsService extends ProviderApiBase {
   constructor (req: any) {
-    super(req);
+    super(req)
   }
 
   async selectInstitution (
     institution: Institution
   ) {
-    logger.debug(`Selecting institution ${institution.id}`);
+    logger.debug(`Selecting institution ${institution.id}`)
     // if (institution.provider) {
     //   context.provider = institution.provider;
     // }
@@ -22,11 +22,11 @@ export class VcsService extends ProviderApiBase {
     //   context.provider = 'sophtron';
     // }
     if (institution.id) {
-      institution = await this.getInstitution(institution.id);
-      const credentials = await this.getInstitutionCredentials(institution.id);
-      return { institution, credentials };
+      institution = await this.getInstitution(institution.id)
+      const credentials = await this.getInstitutionCredentials(institution.id)
+      return { institution, credentials }
     }
-    return { error: 'invalid institution selected' };
+    return { error: 'invalid institution selected' }
   }
 
   async login (
@@ -34,16 +34,16 @@ export class VcsService extends ProviderApiBase {
     connection_id: string | null,
     credentials: Credential[]
   ) {
-    institution_id = this.context.institution_id || institution_id;
-    connection_id = this.context.connection_id || connection_id;
+    institution_id = this.context.institution_id || institution_id
+    connection_id = this.context.connection_id || connection_id
     if (connection_id) {
       const res = await this.updateConnection(
         {
           id: connection_id,
           credentials
         }
-      );
-      return res;
+      )
+      return res
     }
     if (institution_id) {
       const res = await this.createConnection(
@@ -52,27 +52,27 @@ export class VcsService extends ProviderApiBase {
           credentials,
           initial_job_type: this.context.job_type
         }
-      );
+      )
       if (res) {
-        return res;
+        return res
       }
       logger.error(
         `failed creating connection with instituionId : ${institution_id}`
-      );
+      )
       return {
         error: `failed creating connection with instituionId : ${institution_id}`
-      };
+      }
     }
-    return { error: 'Unable to find instituion, invalid parameters provided' };
+    return { error: 'Unable to find instituion, invalid parameters provided' }
   }
 
   async mfa (id: string) {
-    const res = await this.getConnectionStatus(id);
+    const res = await this.getConnectionStatus(id)
     if (!res) {
-      logger.warning(`Mfa failed to find connection with Id: ${id}`);
-      return { error: 'Failed to find job' };
+      logger.warning(`Mfa failed to find connection with Id: ${id}`)
+      return { error: 'Failed to find job' }
     }
-    res.provider = this.context.provider;
-    return res;
+    res.provider = this.context.provider
+    return res
   }
 }

--- a/server/incubationVcs/vcsServiceExpress.js
+++ b/server/incubationVcs/vcsServiceExpress.js
@@ -1,10 +1,10 @@
-const { VcsService } = require('./vcsService');
-const { instrumentation } = require('../providers');
-const { contextHandler } = require('../infra/context.ts');
-const logger = require('../infra/logger');
+const { VcsService } = require('./vcsService')
+const { instrumentation } = require('../providers')
+const { contextHandler } = require('../infra/context.ts')
+const logger = require('../infra/logger')
 
 module.exports = function (app) {
-  app.use(contextHandler);
+  app.use(contextHandler)
   app.post('/api/context', async (req, res) => {
     // res.context = req.body;
     // res.context.job_type = res.context.job_type || 'agg';
@@ -14,62 +14,62 @@ module.exports = function (app) {
     //     res.context.institution_id = conn.institution_code;
     //   }
     // }
-    await instrumentation(req.context, req.body);
-    res.send(req.body);
-    return {};
+    await instrumentation(req.context, req.body)
+    res.send(req.body)
+    return {}
   }),
   app.use(async (req, res, next) => {
     if (req.path.startsWith('/api') && req.path !== '/api/context') {
-      req.vcsService = new VcsService(req);
+      req.vcsService = new VcsService(req)
       if (await req.vcsService.init()) {
         if (!req.context.resolved_user_id) {
-          req.context.resolved_user_id = await req.vcsService.ResolveUserId(req.context.user_id);
+          req.context.resolved_user_id = await req.vcsService.ResolveUserId(req.context.user_id)
         }
       }
     }
-    next();
-  });
+    next()
+  })
   app.post('/api/search', async (req, res) => {
-    const { query } = req.body;
+    const { query } = req.body
     if (query && query.length >= 3) {
-      const data = await req.vcsService.search(query);
-      res.send({ institutions: data });
+      const data = await req.vcsService.search(query)
+      res.send({ institutions: data })
     } else {
-      res.send({ institutions: [] });
+      res.send({ institutions: [] })
     }
-  });
+  })
   app.post('/api/selectInstitution', async (req, res) => {
-    const data = await req.vcsService.selectInstitution(req.body);
-    res.send(data);
-  });
+    const data = await req.vcsService.selectInstitution(req.body)
+    res.send(data)
+  })
   app.post('/api/institutions', async (req, res) => {
-    const data = await req.vcsService.institutions();
-    res.send(data);
-  });
+    const data = await req.vcsService.institutions()
+    res.send(data)
+  })
   app.post('/api/login', async (req, res) => {
     const data = await req.vcsService.login(
       req.body.institution_id,
       req.body.connection_id,
       req.body.credentials
-    );
+    )
     if (data) {
       // res.context.connection_id = data.cur_job_id;
       // res.context.institution_id =
       // res.context.institution_id || data.institution_id;
-      res.send(data);
+      res.send(data)
     } else {
-      res.send({ error: 'Failed creating job' });
+      res.send({ error: 'Failed creating job' })
     }
-  });
+  })
   app.post('/api/mfa', async (req, res) => {
-    const data = await req.vcsService.mfa(req.body.job_id);
-    res.send(data);
-  });
+    const data = await req.vcsService.mfa(req.body.job_id)
+    res.send(data)
+  })
   app.post('/api/answerChallenge', async (req, res) => {
     const data = await req.vcsService.answerChallenge(
       req.body.id,
       req.body.challenges
-    );
-    res.send(data || {});
-  });
-};
+    )
+    res.send(data || {})
+  })
+}

--- a/server/infra/context.ts
+++ b/server/infra/context.ts
@@ -1,51 +1,51 @@
-import type { NextFunction, Request, Response } from 'express';
-import * as config from '../config';
-import * as logger from './logger';
-import { encrypt, decrypt } from '../utils';
+import type { NextFunction, Request, Response } from 'express'
+import * as config from '../config'
+import * as logger from './logger'
+import { encrypt, decrypt } from '../utils'
 
 declare global {
   namespace Express {
     interface Request {
-      context?: import('../../shared/contract').Context;
+      context?: import('../../shared/contract').Context
     }
     interface Response {
-      context?: import('../../shared/contract').Context;
+      context?: import('../../shared/contract').Context
     }
   }
 }
 
-function get(req: Request) {
+function get (req: Request) {
   if (req.headers.meta?.length > 0) {
-    const decrypted = decrypt(<string>req.headers.meta, config.CryptoKey, config.CryptoIv);
-    req.context = JSON.parse(decrypted);
-    req.context.updated = false;
+    const decrypted = decrypt((req.headers.meta as string), config.CryptoKey, config.CryptoIv)
+    req.context = JSON.parse(decrypted)
+    req.context.updated = false
   } else {
-    req.context = {};
+    req.context = {}
   }
-  return req.context;
+  return req.context
 }
 
-function set(res: Response) {
-  if(res.context.updated){
-    res.set('meta', encrypt(JSON.stringify(res.context), config.CryptoKey, config.CryptoIv));
+function set (res: Response) {
+  if (res.context.updated) {
+    res.set('meta', encrypt(JSON.stringify(res.context), config.CryptoKey, config.CryptoIv))
   }
 }
 
-export function contextHandler(
+export function contextHandler (
   req: Request,
   res: Response,
   next: NextFunction
 ) {
-  res.context = get(req);
+  res.context = get(req)
   // console.log('context res: ' + req.path)
   // console.log(res.context)
-  const { send } = res;
+  const { send } = res
   res.send = function (...args: any): any {
-    res.send = send;
-    set(res);
-    send.apply(res, args);
+    res.send = send
+    set(res)
+    send.apply(res, args)
     // console.log('context send: ' + req.path)
     // console.log(res.context)
-  };
-  next();
+  }
+  next()
 }

--- a/server/infra/http/capacitor.js
+++ b/server/infra/http/capacitor.js
@@ -1,59 +1,59 @@
-const logger = require('../logger');
-const { Http } = require('@capacitor-community/http');
+const logger = require('../logger')
+const { Http } = require('@capacitor-community/http')
 
 async function wget (url) {
-  logger.debug(`wget request: ${url}`);
+  logger.debug(`wget request: ${url}`)
   const options = {
     url,
     webFetchExtra: { mode: 'no-cors' },
     responseType: 'text'
-  };
+  }
   const res = await Http.get(options).catch((error) => {
-    logger.error(`error from ${url}`, error);
-    throw error;
-  });
-  logger.debug(`Received wget response from ${url}`);
-  return res.data;
+    logger.error(`error from ${url}`, error)
+    throw error
+  })
+  logger.debug(`Received wget response from ${url}`)
+  return res.data
 }
 
 async function get (url, headers, returnFullResObject) {
-  logger.debug(`get request: ${url}`);
+  logger.debug(`get request: ${url}`)
   const options = {
     url,
     headers,
     webFetchExtra: { mode: 'no-cors' },
     responseType: 'text'
-  };
+  }
   const res = await Http.get(options).catch((error) => {
-    logger.error(`error from ${url}`, error);
-    throw error;
-  });
-  logger.debug(`Received get response from ${url}`);
-  return returnFullResObject ? res : res.data;
+    logger.error(`error from ${url}`, error)
+    throw error
+  })
+  logger.debug(`Received get response from ${url}`)
+  return returnFullResObject ? res : res.data
 }
 
 async function post (url, data, headers, returnFullResObject) {
-  logger.debug(`post request: ${url}`);
+  logger.debug(`post request: ${url}`)
   const options = {
     url,
     headers: { 'content-type': 'application/json', ...headers },
     webFetchExtra: { mode: 'no-cors' },
     responseType: 'text',
     data: data || {}
-  };
+  }
   // console.log(data)
   // logger.debug('posting: ' + options.url);
   const res = await Http.post(options).catch((error) => {
-    logger.error(`error from ${url}`, error);
-    throw error;
-  });
+    logger.error(`error from ${url}`, error)
+    throw error
+  })
   // console.log(res)
-  logger.debug(`Received post response from ${url}`);
-  return returnFullResObject ? res : res.data;
+  logger.debug(`Received post response from ${url}`)
+  return returnFullResObject ? res : res.data
 }
 
 module.exports = {
   get,
   wget,
   post
-};
+}

--- a/server/infra/http/index.js
+++ b/server/infra/http/index.js
@@ -1,9 +1,9 @@
-const config = require('../../config');
-const real = require('./real');
-const mocked = require('./mock');
+const config = require('../../config')
+const real = require('./real')
+const mocked = require('./mock')
 
-const mock = config.Env === 'mocked';
+const mock = config.Env === 'mocked'
 
-const http = mock ? mocked : real;
+const http = mock ? mocked : real
 
-module.exports = http;
+module.exports = http

--- a/server/infra/http/mock.js
+++ b/server/infra/http/mock.js
@@ -1,4 +1,4 @@
-const http = require('./real');
+const http = require('./real')
 
 const mfaRes = [
   {
@@ -15,8 +15,8 @@ const mfaRes = [
   { LastStatus: 'AccountsReady' },
   // {SuccessFlag: false},
   { SuccessFlag: true }
-];
-let counter = 0;
+]
+let counter = 0
 
 const mocks = {
   get: {
@@ -27,7 +27,7 @@ const mocks = {
     // 'v1/user/' + id
     // v1/userprofile
     default: (url) => {
-      console.log(`default mock get: ${url}`);
+      console.log(`default mock get: ${url}`)
     }
   },
   wget: {
@@ -35,8 +35,8 @@ const mocks = {
     '/api/institutions': (url) => http.wget(url),
     '/api/institution/resolve': (url) => http.wget(url),
     default: (url) => {
-      console.log(`Default mock wget: ${url}`);
-      return http.wget(url);
+      console.log(`Default mock wget: ${url}`)
+      return http.wget(url)
     }
   },
   post: {
@@ -93,14 +93,14 @@ const mocks = {
     ],
     '/api/Job/GetJobByID': () => {
       // return {JobID: 'MockedJobId', SuccessFlag: false,  LastStep: 'TokenMethods', LastStatus: 'Timeout'};
-      const mfa = mfaRes[counter % mfaRes.length];
-      counter++;
+      const mfa = mfaRes[counter % mfaRes.length]
+      counter++
       return {
         ...mfa,
         JobID: 'MockedJobID',
         UserInstitutionID: 'MockedUserInstitutionID'
         // SuccessFlag: true,
-      };
+      }
     },
     '/api/Job/UpdateJobSecurityAnswer': () => ({}),
     '/api/Job/UpdateJobTokenInput': () => ({}),
@@ -109,30 +109,30 @@ const mocks = {
       // http.wget('http://localhost:63880/hang')
     },
     default: (url) => {
-      console.log(`default mock post: ${url}`);
+      console.log(`default mock post: ${url}`)
     }
   }
-};
+}
 
 async function getMocks (method, fullUrl) {
-  const path = new URL(fullUrl).pathname;
-  console.log(`Mocking: ${method} ${fullUrl}, path: ${path}`);
+  const path = new URL(fullUrl).pathname
+  console.log(`Mocking: ${method} ${fullUrl}, path: ${path}`)
   if (mocks[method][path]) {
-    return await Promise.resolve(mocks[method][path](fullUrl));
+    return await Promise.resolve(mocks[method][path](fullUrl))
   }
-  return await Promise.resolve(mocks[method].default(fullUrl));
+  return await Promise.resolve(mocks[method].default(fullUrl))
 }
 
 module.exports = {
   async get (url) {
-    return await getMocks('get', url);
+    return await getMocks('get', url)
   },
   async wget (url) {
-    return await getMocks('wget', url);
+    return await getMocks('wget', url)
   },
   async post (url) {
-    return await getMocks('post', url);
+    return await getMocks('post', url)
   },
   stream: http.stream,
   buildAuthCode: http.buildAuthCode
-};
+}

--- a/server/infra/http/real.js
+++ b/server/infra/http/real.js
@@ -1,8 +1,8 @@
-const crypto = require('crypto');
-const axios = require('axios');
-const logger = require('../logger');
-const capacitor = require('./capacitor');
-const config = require('../../config');
+const crypto = require('crypto')
+const axios = require('axios')
+const logger = require('../logger')
+const capacitor = require('./capacitor')
+const config = require('../../config')
 
 function stream (url, data, target) {
   // logger.debug(`stream request: ${url}`);
@@ -14,64 +14,64 @@ function stream (url, data, target) {
   })
     .then((res) => {
       // logger.debug(`Received stream response from ${url}`);
-      return res;
+      return res
     })
     .catch((error) => {
       if (error.response) {
-        logger.error(`error from ${url}`, error.response.status);
-        return error.response;
+        logger.error(`error from ${url}`, error.response.status)
+        return error.response
       }
-      logger.error(`error from ${url}`, error);
+      logger.error(`error from ${url}`, error)
 
-      return undefined;
+      return undefined
     })
     .then((res) => {
       if (res?.headers) {
         if (res.headers['content-type']) {
-          target.setHeader('content-type', res.headers['content-type']);
+          target.setHeader('content-type', res.headers['content-type'])
         }
-        return res.data.pipe(target);
+        return res.data.pipe(target)
       }
-      target.status(500).send('unexpected error');
+      target.status(500).send('unexpected error')
 
-      return undefined;
-    });
+      return undefined
+    })
 }
 
 function handleResponse (promise, url, method, returnFullResObject) {
   return promise.then((res) => {
-    logger.debug(`Received ${method} response from ${url}`);
-    return returnFullResObject ? res : res.data;
+    logger.debug(`Received ${method} response from ${url}`)
+    return returnFullResObject ? res : res.data
   })
     .catch((error) => {
-      logger.error(`error ${method} from ${url}`, error);
-      throw error;
-    });
+      logger.error(`error ${method} from ${url}`, error)
+      throw error
+    })
 }
 
 function wget (url) {
-  logger.debug(`wget request: ${url}`);
-  return handleResponse(axios.get(url), url, 'wget');
+  logger.debug(`wget request: ${url}`)
+  return handleResponse(axios.get(url), url, 'wget')
 }
 
 function get (url, headers, returnFullResObject) {
-  logger.debug(`get request: ${url}`);
-  return handleResponse(axios.get(url, { headers }), url, 'get', returnFullResObject);
+  logger.debug(`get request: ${url}`)
+  return handleResponse(axios.get(url, { headers }), url, 'get', returnFullResObject)
 }
 
 function del (url, headers, returnFullResObject) {
-  logger.debug(`del request: ${url}`);
-  return handleResponse(axios.delete(url, { headers }), url, 'del', returnFullResObject);
+  logger.debug(`del request: ${url}`)
+  return handleResponse(axios.delete(url, { headers }), url, 'del', returnFullResObject)
 }
 
 function put (url, data, headers, returnFullResObject) {
-  logger.debug(`put request: ${url}`);
-  return handleResponse(axios.put(url, data, { headers }), url, 'put', returnFullResObject);
+  logger.debug(`put request: ${url}`)
+  return handleResponse(axios.put(url, data, { headers }), url, 'put', returnFullResObject)
 }
 
 function post (url, data, headers, returnFullResObject) {
-  logger.debug(`post request: ${url}`);
-  return handleResponse(axios.post(url, data, { headers }), url, 'post', returnFullResObject);
+  logger.debug(`post request: ${url}`)
+  return handleResponse(axios.post(url, data, { headers }), url, 'post', returnFullResObject)
 }
 
 module.exports = {
@@ -81,4 +81,4 @@ module.exports = {
   put: config.UseAxios ? put : capacitor.put,
   del: config.UseAxios ? del : capacitor.del,
   stream
-};
+}

--- a/server/infra/logger.js
+++ b/server/infra/logger.js
@@ -1,4 +1,4 @@
-const config = require('../config');
+const config = require('../config')
 
 const levels = {
   debug: -1,
@@ -6,7 +6,7 @@ const levels = {
   info: 1,
   warning: 2,
   error: 3
-};
+}
 
 function startDoc () {
   return {
@@ -15,38 +15,38 @@ function startDoc () {
     Env: config.Env || 'development',
     Request: {},
     '@timestamp': new Date().toISOString()
-  };
+  }
 }
 
 function logDoc (doc) {
   if (levels[config.LogLevel.toLowerCase()] > levels[doc.Level.toLowerCase()]) {
-    return;
+    return
   }
   if (
     config.Env === 'dev' ||
     config.Env === 'local' ||
     config.Env === 'mocked'
   ) {
-    console.log(doc);
+    console.log(doc)
   } else {
-    console.log(JSON.stringify(doc));
+    console.log(JSON.stringify(doc))
   }
 }
 
 function logMessage (message, level, data, isError) {
-  const doc = startDoc();
-  doc.Level = level || doc.Level;
-  doc.Message = message;
+  const doc = startDoc()
+  doc.Level = level || doc.Level
+  doc.Message = message
   if (isError && data) {
-    doc.Error = { message: data.message || data, stack: data.stack };
+    doc.Error = { message: data.message || data, stack: data.stack }
   } else {
-    doc.Data = data;
+    doc.Data = data
   }
-  logDoc(doc);
+  logDoc(doc)
 }
 
-exports.error = (message, error) => { logMessage(message, 'error', error, true); };
-exports.info = (message, data) => { logMessage(message, 'info', data); };
-exports.warning = (message, data) => { logMessage(message, 'warning', data); };
-exports.trace = (message, data) => { logMessage(message, 'trace', data); };
-exports.debug = (message, data) => { logMessage(message, 'debug', data); };
+exports.error = (message, error) => { logMessage(message, 'error', error, true) }
+exports.info = (message, data) => { logMessage(message, 'info', data) }
+exports.warning = (message, data) => { logMessage(message, 'warning', data) }
+exports.trace = (message, data) => { logMessage(message, 'trace', data) }
+exports.debug = (message, data) => { logMessage(message, 'debug', data) }

--- a/server/infra/utils/index.js
+++ b/server/infra/utils/index.js
@@ -1,62 +1,62 @@
-const config = require('../config');
-const CryptoJS = require('crypto-js');
-const crypto = require('crypto');
+const config = require('../config')
+const CryptoJS = require('crypto-js')
+const crypto = require('crypto')
 
 function hmac (text, key) {
-  const hmac = CryptoJS.algo.HMAC.create(CryptoJS.algo.SHA256, CryptoJS.enc.Base64.parse(key));
-  hmac.update(text);
-  return CryptoJS.enc.Base64.stringify(hmac.finalize());
+  const hmac = CryptoJS.algo.HMAC.create(CryptoJS.algo.SHA256, CryptoJS.enc.Base64.parse(key))
+  hmac.update(text)
+  return CryptoJS.enc.Base64.stringify(hmac.finalize())
 }
 
 function buildSophtronAuthCode (httpMethod, url, apiUserID, secret) {
-  const authPath = url.substring(url.lastIndexOf('/')).toLowerCase();
-  const text = httpMethod.toUpperCase() + '\n' + authPath;
-  const b64Sig = hmac(text, secret);
-  const authString = 'FIApiAUTH:' + apiUserID + ':' + b64Sig + ':' + authPath;
-  return authString;
+  const authPath = url.substring(url.lastIndexOf('/')).toLowerCase()
+  const text = httpMethod.toUpperCase() + '\n' + authPath
+  const b64Sig = hmac(text, secret)
+  const authString = 'FIApiAUTH:' + apiUserID + ':' + b64Sig + ':' + authPath
+  return authString
 }
 
-const algorithm = config.CryptoAlgorithm;
+const algorithm = config.CryptoAlgorithm
 
 function encrypt (text, keyHex, ivHex) {
   if (!text) {
-    return '';
+    return ''
   }
-  const key = Buffer.from(keyHex, 'hex');
-  const iv = Buffer.from(ivHex, 'hex');
-  const cipher = crypto.createCipheriv(algorithm, key, iv);
-  let encrypted = cipher.update(text);
-  encrypted = Buffer.concat([encrypted, cipher.final()]);
-  return encrypted.toString('hex');
+  const key = Buffer.from(keyHex, 'hex')
+  const iv = Buffer.from(ivHex, 'hex')
+  const cipher = crypto.createCipheriv(algorithm, key, iv)
+  let encrypted = cipher.update(text)
+  encrypted = Buffer.concat([encrypted, cipher.final()])
+  return encrypted.toString('hex')
 }
 
 function decrypt (text, keyHex, ivHex) {
   if (!text) {
-    return '';
+    return ''
   }
-  const key = Buffer.from(keyHex, 'hex');
-  const iv = Buffer.from(ivHex, 'hex');
-  const encryptedText = Buffer.from(text, 'hex');
-  const decipher = crypto.createDecipheriv(algorithm, key, iv);
-  let decrypted = decipher.update(encryptedText);
-  decrypted = Buffer.concat([decrypted, decipher.final()]);
-  return decrypted.toString();
+  const key = Buffer.from(keyHex, 'hex')
+  const iv = Buffer.from(ivHex, 'hex')
+  const encryptedText = Buffer.from(text, 'hex')
+  const decipher = crypto.createDecipheriv(algorithm, key, iv)
+  let decrypted = decipher.update(encryptedText)
+  decrypted = Buffer.concat([decrypted, decipher.final()])
+  return decrypted.toString()
 }
 
 function decodeAuthToken (input) {
   try {
-    const str = Buffer.from(input, 'base64').toString('utf-8');
-    const arr = str.split(';');
+    const str = Buffer.from(input, 'base64').toString('utf-8')
+    const arr = str.split(';')
     if (arr.length !== 3) {
-      return input;
+      return input
     }
     return {
       provider: arr[0],
       token: arr[1],
       iv: arr[2]
-    };
+    }
   } catch (err) {
-    return input;
+    return input
   }
 }
 
@@ -66,4 +66,4 @@ module.exports = {
   hmac,
   buildSophtronAuthCode,
   decodeAuthToken
-};
+}

--- a/server/providers/akoya.ts
+++ b/server/providers/akoya.ts
@@ -1,62 +1,62 @@
 import {
   Challenge,
   ChallengeType,
-  Connection,
+  type Connection,
   ConnectionStatus,
-  CreateConnectionRequest,
-  Credential,
-  Institution,
+  type CreateConnectionRequest,
+  type Credential,
+  type Institution,
   Institutions,
-  ProviderApiClient,
-  UpdateConnectionRequest,
-  VcType,
-} from '@/../../shared/contract';
-import * as logger from '../infra/logger';
-import AkoyaClient from '../serviceClients/akoyaClient';
-import { StorageClient } from'../serviceClients/storageClient';
+  type ProviderApiClient,
+  type UpdateConnectionRequest,
+  VcType
+} from '@/../../shared/contract'
+import * as logger from '../infra/logger'
+import AkoyaClient from '../serviceClients/akoyaClient'
+import { StorageClient } from '../serviceClients/storageClient'
 
-const {  v4: uuidv4, } = require('uuid');
+const { v4: uuidv4 } = require('uuid')
 
 export class AkoyaApi implements ProviderApiClient {
-  sandbox: boolean;
-  apiClient: any;
-  db: StorageClient;
-  token: string;
-  constructor(config: any, sandbox: boolean) {
-    const { akoyaProd, akoyaSandbox, token } = config;
-    this.token = token;
-    this.db = new StorageClient(token);
-    this.sandbox = sandbox;
-    this.apiClient = new AkoyaClient(sandbox ? akoyaSandbox : akoyaProd);
+  sandbox: boolean
+  apiClient: any
+  db: StorageClient
+  token: string
+  constructor (config: any, sandbox: boolean) {
+    const { akoyaProd, akoyaSandbox, token } = config
+    this.token = token
+    this.db = new StorageClient(token)
+    this.sandbox = sandbox
+    this.apiClient = new AkoyaClient(sandbox ? akoyaSandbox : akoyaProd)
   }
 
-  GetInstitutionById(id: string): Promise<Institution> {
-    return Promise.resolve({
-      id, 
+  async GetInstitutionById (id: string): Promise<Institution> {
+    return await Promise.resolve({
+      id,
       name: null,
       logo_url: null,
       url: null,
       oauth: true,
       provider: this.apiClient.apiConfig.provider
-    });
+    })
   }
 
-  async ListInstitutionCredentials(id: string): Promise<Array<Credential>> {
-    return Promise.resolve([]);
+  async ListInstitutionCredentials (id: string): Promise<Credential[]> {
+    return await Promise.resolve([])
   }
 
-  async ListConnectionCredentials(connectionId: string, userId: string): Promise<Credential[]> {
-    return Promise.resolve([]);
+  async ListConnectionCredentials (connectionId: string, userId: string): Promise<Credential[]> {
+    return await Promise.resolve([])
   }
 
-  ListConnections(userId: string): Promise<Connection[]> {
-    return Promise.resolve([]);
+  async ListConnections (userId: string): Promise<Connection[]> {
+    return await Promise.resolve([])
   }
 
-  async CreateConnection(
+  async CreateConnection (
     request: CreateConnectionRequest
   ): Promise<Connection | undefined> {
-    const request_id = `${this.token}${uuidv4().replaceAll('-', '')}`;
+    const request_id = `${this.token}${uuidv4().replaceAll('-', '')}`
     const obj = {
       id: request_id,
       is_oauth: true,
@@ -65,53 +65,53 @@ export class AkoyaApi implements ProviderApiClient {
       oauth_window_uri: this.apiClient.getOauthUrl(request.institution_id, this.apiClient.client_redirect_url, request_id),
       provider: this.apiClient.apiConfig.provider,
       status: ConnectionStatus.PENDING
-    };
-    await this.db.set(request_id, obj);
-    return obj;
+    }
+    await this.db.set(request_id, obj)
+    return obj
   }
 
-  DeleteConnection(id: string): Promise<void> {
-    return this.db.set(id, null);
+  async DeleteConnection (id: string): Promise<void> {
+    return await this.db.set(id, null)
   }
 
-  async UpdateConnection(
+  async UpdateConnection (
     request: UpdateConnectionRequest
   ): Promise<Connection> {
-    return null;
+    return null
   }
 
-  GetConnectionById(connectionId: string): Promise<Connection> {
-    return this.db.get(connectionId);
+  async GetConnectionById (connectionId: string): Promise<Connection> {
+    return await this.db.get(connectionId)
   }
 
-  async GetConnectionStatus(connectionId: string, jobId: string, single_account_select?: boolean, user_id?: string): Promise<Connection> {
-    return this.db.get(connectionId);
+  async GetConnectionStatus (connectionId: string, jobId: string, single_account_select?: boolean, user_id?: string): Promise<Connection> {
+    return await this.db.get(connectionId)
   }
 
-  async AnswerChallenge(request: UpdateConnectionRequest, jobId: string): Promise<boolean> {
-    return true;
+  async AnswerChallenge (request: UpdateConnectionRequest, jobId: string): Promise<boolean> {
+    return true
   }
 
-  async ResolveUserId(user_id: string){
-    return user_id;
+  async ResolveUserId (user_id: string) {
+    return user_id
   }
 
-  static async HandleOauthResponse(request: any): Promise<Connection> {
-    const { state: request_id, code } = request;
-    logger.info(`Received akoya oauth redirect response ${request_id}`);
-    const db = new StorageClient(request_id.substring(0, request_id.length - 32));
-    let connection = await db.get(request_id);
-    if(!connection){
-      return null;
+  static async HandleOauthResponse (request: any): Promise<Connection> {
+    const { state: request_id, code } = request
+    logger.info(`Received akoya oauth redirect response ${request_id}`)
+    const db = new StorageClient(request_id.substring(0, request_id.length - 32))
+    const connection = await db.get(request_id)
+    if (!connection) {
+      return null
     }
-    if(code){
-      connection.status = ConnectionStatus.CONNECTED;
-      connection.guid = connection.institution_code;
-      connection.id = connection.institution_code;
-      connection.user_id = code;
+    if (code) {
+      connection.status = ConnectionStatus.CONNECTED
+      connection.guid = connection.institution_code
+      connection.id = connection.institution_code
+      connection.user_id = code
     }
     // console.log(connection)
-    await db.set(request_id, connection);
-    return connection;
+    await db.set(request_id, connection)
+    return connection
   }
 }

--- a/server/providers/finicity.ts
+++ b/server/providers/finicity.ts
@@ -1,64 +1,64 @@
 import {
   Challenge,
   ChallengeType,
-  Connection,
+  type Connection,
   ConnectionStatus,
-  CreateConnectionRequest,
-  Credential,
-  Institution,
+  type CreateConnectionRequest,
+  type Credential,
+  type Institution,
   Institutions,
-  ProviderApiClient,
-  UpdateConnectionRequest,
-  VcType,
-} from '@/../../shared/contract';
-import * as logger from '../infra/logger';
-import FinicityClient from '../serviceClients/finicityClient';
-import { StorageClient } from'../serviceClients/storageClient';
+  type ProviderApiClient,
+  type UpdateConnectionRequest,
+  VcType
+} from '@/../../shared/contract'
+import * as logger from '../infra/logger'
+import FinicityClient from '../serviceClients/finicityClient'
+import { StorageClient } from '../serviceClients/storageClient'
 
-const { v4: uuidv4, } = require('uuid');
+const { v4: uuidv4 } = require('uuid')
 
 export class FinicityApi implements ProviderApiClient {
-  sandbox: boolean;
-  apiClient: any;
-  db: StorageClient;
-  token: string;
-  constructor(config:any, sandbox: boolean) {
-    const { finicityProd, finicitySandbox, token } = config;
-    this.token = token;
-    this.db = new StorageClient(token);
-    this.sandbox = sandbox;
-    this.apiClient = new FinicityClient(sandbox ? finicitySandbox : finicityProd);
+  sandbox: boolean
+  apiClient: any
+  db: StorageClient
+  token: string
+  constructor (config: any, sandbox: boolean) {
+    const { finicityProd, finicitySandbox, token } = config
+    this.token = token
+    this.db = new StorageClient(token)
+    this.sandbox = sandbox
+    this.apiClient = new FinicityClient(sandbox ? finicitySandbox : finicityProd)
   }
 
-  async GetInstitutionById(id: string): Promise<Institution> {
-    const ins = this.apiClient.getInstitution(id);
+  async GetInstitutionById (id: string): Promise<Institution> {
+    const ins = this.apiClient.getInstitution(id)
     return {
-      id, 
+      id,
       name: ins?.name,
       logo_url: ins?.urlLogonApp,
       url: ins?.urlHomeApp,
       oauth: true,
       provider: this.apiClient.apiConfig.provider
-    };
+    }
   }
 
-  async ListInstitutionCredentials(id: string): Promise<Array<Credential>> {
-    return Promise.resolve([]);
+  async ListInstitutionCredentials (id: string): Promise<Credential[]> {
+    return await Promise.resolve([])
   }
 
-  async ListConnectionCredentials(connectionId: string, userId: string): Promise<Credential[]> {
-    return Promise.resolve([]);
+  async ListConnectionCredentials (connectionId: string, userId: string): Promise<Credential[]> {
+    return await Promise.resolve([])
   }
 
-  ListConnections(userId: string): Promise<Connection[]> {
-    return Promise.resolve([]);
+  async ListConnections (userId: string): Promise<Connection[]> {
+    return await Promise.resolve([])
   }
 
-  async CreateConnection(
+  async CreateConnection (
     request: CreateConnectionRequest,
     user_id: string
   ): Promise<Connection | undefined> {
-    const request_id = `${this.token};${uuidv4()}`;
+    const request_id = `${this.token};${uuidv4()}`
     const obj = {
       id: request_id,
       is_oauth: true,
@@ -68,91 +68,90 @@ export class FinicityApi implements ProviderApiClient {
       oauth_window_uri: await this.apiClient.generateConnectLiteUrl(request.institution_id, user_id, request_id),
       provider: this.apiClient.apiConfig.provider,
       status: ConnectionStatus.PENDING
-    };
-    await this.db.set(request_id, obj);
-    return obj;
+    }
+    await this.db.set(request_id, obj)
+    return obj
   }
 
-  DeleteConnection(id: string): Promise<void> {
-    return this.db.set(id, null);
+  async DeleteConnection (id: string): Promise<void> {
+    return await this.db.set(id, null)
   }
 
-  async UpdateConnection(
+  async UpdateConnection (
     request: UpdateConnectionRequest,
-    user_id: string,
+    user_id: string
   ): Promise<Connection> {
-    return null;
+    return null
   }
 
-  GetConnectionById(connectionId: string, user_id: string): Promise<Connection> {
-    return this.getConnection(connectionId, user_id);
+  async GetConnectionById (connectionId: string, user_id: string): Promise<Connection> {
+    return await this.getConnection(connectionId, user_id)
   }
 
-  GetConnectionStatus(connectionId: string, jobId: string, single_account_select?: boolean, user_id?: string): Promise<Connection> {
-    return this.getConnection(connectionId, user_id);
+  async GetConnectionStatus (connectionId: string, jobId: string, single_account_select?: boolean, user_id?: string): Promise<Connection> {
+    return await this.getConnection(connectionId, user_id)
   }
 
-  async AnswerChallenge(request: UpdateConnectionRequest, jobId: string): Promise<boolean> {
-    return true;
+  async AnswerChallenge (request: UpdateConnectionRequest, jobId: string): Promise<boolean> {
+    return true
   }
 
-  async ResolveUserId(user_id: string){
-    logger.debug('Resolving UserId: ' + user_id);
-    const finicityUser = await this.apiClient.getCustomer(user_id);
-    if(finicityUser){
-      logger.trace(`Found existing finicity customer ${finicityUser.id}`);
-      return finicityUser.id;
+  async ResolveUserId (user_id: string) {
+    logger.debug('Resolving UserId: ' + user_id)
+    const finicityUser = await this.apiClient.getCustomer(user_id)
+    if (finicityUser) {
+      logger.trace(`Found existing finicity customer ${finicityUser.id}`)
+      return finicityUser.id
     }
-    logger.trace(`Creating finicity user ${user_id}`);
-    let ret = await this.apiClient.createCustomer(user_id);
-    if(ret){
-      return ret.id;
+    logger.trace(`Creating finicity user ${user_id}`)
+    const ret = await this.apiClient.createCustomer(user_id)
+    if (ret) {
+      return ret.id
     }
-    logger.trace(`Failed creating finicity user, using user_id: ${user_id}`);
-    return user_id;
+    logger.trace(`Failed creating finicity user, using user_id: ${user_id}`)
+    return user_id
   }
 
-  static async HandleOauthResponse(request: any): Promise<Connection> {
-    const {connection_id, eventType, reason, code} = request;
-    const db = new StorageClient(connection_id.split(';')[0]);
-    let institutionLoginId = false;
-    switch(eventType){
+  static async HandleOauthResponse (request: any): Promise<Connection> {
+    const { connection_id, eventType, reason, code } = request
+    const db = new StorageClient(connection_id.split(';')[0])
+    let institutionLoginId = false
+    switch (eventType) {
       case 'added':
-        institutionLoginId = request.payload.accounts?.[0]?.institutionLoginId;
-        break;
+        institutionLoginId = request.payload.accounts?.[0]?.institutionLoginId
+        break
       default:
-        switch(reason){
+        switch (reason) {
           case 'error':
-            if(code === '201'){
-              // refresh but unnecessary 
-              institutionLoginId = connection_id.split(';')[1];
+            if (code === '201') {
+              // refresh but unnecessary
+              institutionLoginId = connection_id.split(';')[1]
             }
-            break;
+            break
         }
-      
     }
-    logger.info(`Received finicity webhook response ${connection_id}`);
-    let connection = await db.get(connection_id);
-    if(!connection){
-      return null;
+    logger.info(`Received finicity webhook response ${connection_id}`)
+    const connection = await db.get(connection_id)
+    if (!connection) {
+      return null
     }
-    if(institutionLoginId){
-      connection.status = ConnectionStatus.CONNECTED;
-      connection.guid = connection_id;
-      connection.id = `${institutionLoginId}`;
+    if (institutionLoginId) {
+      connection.status = ConnectionStatus.CONNECTED
+      connection.guid = connection_id
+      connection.id = `${institutionLoginId}`
     }
-    await db.set(connection_id, connection);
-    return connection;
+    await db.set(connection_id, connection)
+    return connection
   }
 
-  async getConnection(id: string, user_id: string){
-    if(id.startsWith(this.token)){
-      return await this.db.get(id);
-    }else{
-      let request_id = `${this.token};${id}`;
-      let existing = await this.db.get(request_id);
-      if(existing?.id){
-        return existing;
+  async getConnection (id: string, user_id: string) {
+    if (id.startsWith(this.token)) {
+      return await this.db.get(id)
+    } else {
+      const request_id = `${this.token};${id}`
+      const existing = await this.db.get(request_id)
+      if (existing?.id) {
+        return existing
       }
       const obj = {
         id: request_id,
@@ -162,9 +161,9 @@ export class FinicityApi implements ProviderApiClient {
         oauth_window_uri: await this.apiClient.generateConnectFixUrl(id, user_id, request_id),
         provider: this.apiClient.apiConfig.provider,
         status: ConnectionStatus.PENDING
-      };
-      await this.db.set(request_id, obj);
-      return obj;
+      }
+      await this.db.set(request_id, obj)
+      return obj
     }
   }
 }

--- a/server/providers/index.ts
+++ b/server/providers/index.ts
@@ -1,9 +1,9 @@
-import { MxApi } from './mx';
-import { SophtronApi } from './sophtron';
-import { AkoyaApi } from './akoya';
-import { FinicityApi } from './finicity';
-import * as config from '../config.js';
-import * as logger from '../infra/logger';
+import { MxApi } from './mx'
+import { SophtronApi } from './sophtron'
+import { AkoyaApi } from './akoya'
+import { FinicityApi } from './finicity'
+import * as config from '../config.js'
+import * as logger from '../infra/logger'
 import {
   type Challenge,
   ChallengeType,
@@ -16,93 +16,93 @@ import {
   VcType,
   type CreateConnectionRequest,
   type UpdateConnectionRequest
-} from '../../shared/contract';
-import { AnalyticsClient } from '../serviceClients/analyticsClient';
-import { SearchClient } from '../serviceClients/searchClient';
-import { AuthClient } from '../serviceClients/authClient';
-import { StorageClient } from '../serviceClients/storageClient';
-import { decodeAuthToken } from '../utils';
+} from '../../shared/contract'
+import { AnalyticsClient } from '../serviceClients/analyticsClient'
+import { SearchClient } from '../serviceClients/searchClient'
+import { AuthClient } from '../serviceClients/authClient'
+import { StorageClient } from '../serviceClients/storageClient'
+import { decodeAuthToken } from '../utils'
 
 function getApiClient (provider: string, config: any): ProviderApiClient {
   // console.log(config)
   switch (provider) {
     case 'mx':
-      return new MxApi(config, false);
+      return new MxApi(config, false)
     case 'mx_int':
-      return new MxApi(config, true);
+      return new MxApi(config, true)
     case 'sophtron':
-      return new SophtronApi(config);
+      return new SophtronApi(config)
     case 'akoya':
-      return new AkoyaApi(config, false);
+      return new AkoyaApi(config, false)
     case 'akoya_sandbox':
-      return new AkoyaApi(config, true);
+      return new AkoyaApi(config, true)
     case 'finicity':
-      return new FinicityApi(config, false);
+      return new FinicityApi(config, false)
     case 'finicity_sandbox':
-      return new FinicityApi(config, true);
+      return new FinicityApi(config, true)
     default:
       // throw new Error(`Unsupported provider ${provider}`);
-      return null;
+      return null
   }
 }
 
 export async function instrumentation (context: Context, input: any) {
-  const { user_id } = input;
-  context.user_id = user_id;
+  const { user_id } = input
+  context.user_id = user_id
   if (!user_id || user_id === 'undefined' || user_id === 'test') {
     if (config.Demo) {
-      logger.info('Using demo userId');
-      context.user_id = 'Universal_widget_demo_user';
+      logger.info('Using demo userId')
+      context.user_id = 'Universal_widget_demo_user'
     } else {
-      logger.info('Missing userId');
-      return false;
+      logger.info('Missing userId')
+      return false
     }
   }
   if (input.current_member_guid && input.current_provider) {
-    context.provider = input.current_provider;
-    context.connection_id = input.current_member_guid;
+    context.provider = input.current_provider
+    context.connection_id = input.current_member_guid
   }
   if (input.auth) {
-    context.auth = decodeAuthToken(input.auth);
+    context.auth = decodeAuthToken(input.auth)
   }
-  context.partner = input.current_partner;
-  context.job_type = input.job_type || 'agg';
-  context.oauth_referral_source = input.oauth_referral_source || 'BROWSER';
-  context.single_account_select = input.single_account_select;
-  context.updated = true;
-  return true;
+  context.partner = input.current_partner
+  context.job_type = input.job_type || 'agg'
+  context.oauth_referral_source = input.oauth_referral_source || 'BROWSER'
+  context.single_account_select = input.single_account_select
+  context.updated = true
+  return true
 }
 
 export class ProviderApiBase {
-  context: Context;
-  serviceClient: ProviderApiClient;
-  analyticsClient: AnalyticsClient;
-  searchApi: SearchClient;
-  providers: string[];
+  context: Context
+  serviceClient: ProviderApiClient
+  analyticsClient: AnalyticsClient
+  searchApi: SearchClient
+  providers: string[]
   constructor (req: any) {
-    this.context = req.context;
+    this.context = req.context
   }
 
   async init () {
-    this.searchApi = new SearchClient(this.context.auth?.token);
+    this.searchApi = new SearchClient(this.context.auth?.token)
     if (this.context.auth?.token) {
-      const { iv, token } = this.context.auth;
-      const storageClient = new StorageClient(token);
-      this.analyticsClient = new AnalyticsClient(token);
+      const { iv, token } = this.context.auth
+      const storageClient = new StorageClient(token)
+      this.analyticsClient = new AnalyticsClient(token)
       if (iv) {
         try {
-          const authApi = new AuthClient(token);
-          const conf = await authApi.getSecretExchange(iv);
-          conf.sophtron.token = token;
-          conf.token = token;
+          const authApi = new AuthClient(token)
+          const conf = await authApi.getSecretExchange(iv)
+          conf.sophtron.token = token
+          conf.token = token
           this.serviceClient = getApiClient(this.context?.provider, {
             ...conf,
             storageClient
-          });
-          this.providers = Object.values(conf).filter((v: any) => v.available).map((v: any) => v.provider);
-          return true;
+          })
+          this.providers = Object.values(conf).filter((v: any) => v.available).map((v: any) => v.provider)
+          return true
         } catch (err) {
-          logger.error('Error parsing auth token', err);
+          logger.error('Error parsing auth token', err)
         }
       }
     }
@@ -111,93 +111,93 @@ export class ProviderApiBase {
     //   this.serviceClient = getApiClient(this.context?.provider, Config);
     //   return true;
     // }
-    logger.warning('invalid auth token');
-    return false;
+    logger.warning('invalid auth token')
+    return false
   }
 
   async institutions () {
-    return await this.searchApi.institutions();
+    return await this.searchApi.institutions()
   }
 
   async search (query: string) {
-    this.context.updated = true;
-    this.context.provider = null;
-    const q = query as any;
+    this.context.updated = true
+    this.context.provider = null
+    const q = query as any
     if (q.search_name) {
-      query = q.search_name;
+      query = q.search_name
     }
     if (query?.length >= 3) {
-      const list = await this.searchApi.institutions(query, this.providers);
-      return list?.institutions?.sort((a: any, b: any) => a.name.length - b.name.length);
+      const list = await this.searchApi.institutions(query, this.providers)
+      return list?.institutions?.sort((a: any, b: any) => a.name.length - b.name.length)
     }
-    return [];
+    return []
   }
 
   async resolveInstitution (id: string): Promise<Institution> {
-    this.context.updated = true;
+    this.context.updated = true
     const ret = {
       id
-    } as any;
+    } as any
     if (!this.context.provider || (this.context.institution_uid && this.context.institution_uid != id && this.context.institution_id != id)) {
-      const resolved = await this.searchApi.resolve(id);
+      const resolved = await this.searchApi.resolve(id)
       if (resolved) {
-        logger.debug(`resolved institution ${id} to provider ${resolved.provider} ${resolved.target_id}`);
-        this.context.provider = resolved.provider;
-        this.context.institution_uid = id;
-        ret.id = resolved.target_id;
-        ret.url = resolved.url;
-        ret.name = resolved.name;
-        ret.logo_url = resolved.logo_url;
+        logger.debug(`resolved institution ${id} to provider ${resolved.provider} ${resolved.target_id}`)
+        this.context.provider = resolved.provider
+        this.context.institution_uid = id
+        ret.id = resolved.target_id
+        ret.url = resolved.url
+        ret.name = resolved.name
+        ret.logo_url = resolved.logo_url
       }
     }
     if (!this.context.provider) {
-      this.context.provider = config.DefaultProvider;
+      this.context.provider = config.DefaultProvider
     }
-    await this.init();
-    this.context.institution_id = ret.id;
-    this.context.resolved_user_id = null;
-    return ret;
+    await this.init()
+    this.context.institution_id = ret.id
+    this.context.resolved_user_id = null
+    return ret
   }
 
   async getInstitution (guid: string): Promise<any> {
-    const resolved = await this.resolveInstitution(guid);
-    const inst = await this.serviceClient.GetInstitutionById(resolved.id);
+    const resolved = await this.resolveInstitution(guid)
+    const inst = await this.serviceClient.GetInstitutionById(resolved.id)
     if (inst) {
-      inst.name = resolved.name || inst.name;
-      inst.url = resolved?.url || inst.url?.trim();
-      inst.logo_url = resolved?.logo_url || inst.logo_url?.trim();
+      inst.name = resolved.name || inst.name
+      inst.url = resolved?.url || inst.url?.trim()
+      inst.logo_url = resolved?.logo_url || inst.logo_url?.trim()
     }
-    return inst;
+    return inst
   }
 
   async getInstitutionCredentials (guid: string): Promise<Credential[]> {
-    this.context.updated = true;
-    this.context.current_job_id = null;
+    this.context.updated = true
+    this.context.current_job_id = null
     // let id = await this.resolveInstitution(guid)
-    return await this.serviceClient.ListInstitutionCredentials(guid);
+    return await this.serviceClient.ListInstitutionCredentials(guid)
   }
 
   async getConnection (connection_id: string): Promise<Connection> {
-    return await this.serviceClient.GetConnectionById(connection_id, this.getUserId());
+    return await this.serviceClient.GetConnectionById(connection_id, this.getUserId())
   }
 
   async getConnectionStatus (connection_id: string): Promise<Connection> {
-    return await this.serviceClient.GetConnectionStatus(connection_id, this.context.current_job_id, this.context.single_account_select, this.getUserId());
+    return await this.serviceClient.GetConnectionStatus(connection_id, this.context.current_job_id, this.context.single_account_select, this.getUserId())
   }
 
   async createConnection (connection: CreateConnectionRequest): Promise<Connection> {
-    this.context.updated = true;
-    this.context.current_job_id = null;
-    const ret = await this.serviceClient.CreateConnection(connection, this.getUserId());
-    this.context.current_job_id = ret.cur_job_id;
-    return ret;
+    this.context.updated = true
+    this.context.current_job_id = null
+    const ret = await this.serviceClient.CreateConnection(connection, this.getUserId())
+    this.context.current_job_id = ret.cur_job_id
+    return ret
   }
 
   async updateConnection (connection: UpdateConnectionRequest): Promise<Connection> {
-    const ret = await this.serviceClient.UpdateConnection(connection, this.getUserId());
-    this.context.updated = true;
-    this.context.current_job_id = ret.cur_job_id;
-    return ret;
+    const ret = await this.serviceClient.UpdateConnection(connection, this.getUserId())
+    this.context.updated = true
+    this.context.current_job_id = ret.cur_job_id
+    return ret
   }
 
   async answerChallenge (connection_id: string, challenges: Challenge[]) {
@@ -208,81 +208,81 @@ export class ProviderApiBase {
       },
       this.context.current_job_id,
       this.getUserId()
-    );
+    )
   }
 
   async getOauthWindowUri (memberGuid: string) {
-    const ret = await this.getConnection(memberGuid);
-    return ret?.oauth_window_uri;
+    const ret = await this.getConnection(memberGuid)
+    return ret?.oauth_window_uri
   }
 
   async getOauthState (connection_id: string) {
-    const connection = await this.getConnectionStatus(connection_id);
-    if(!connection){
-      return {};
+    const connection = await this.getConnectionStatus(connection_id)
+    if (!connection) {
+      return {}
     }
     const ret = {
       guid: connection_id,
       inbound_member_guid: connection_id,
       outbound_member_guid: connection_id,
       auth_status: connection.status === ConnectionStatus.PENDING ? 1 : ConnectionStatus.CONNECTED ? 2 : 3
-    } as any;
+    } as any
     if (ret.auth_status === 3) {
-      ret.error_reason = connection.status;
+      ret.error_reason = connection.status
     }
-    return { oauth_state: ret };
+    return { oauth_state: ret }
   }
 
   async getOauthStates (memberGuid: string) {
-    const state = await this.getOauthState(memberGuid);
+    const state = await this.getOauthState(memberGuid)
     return {
       oauth_states: [
         state.oauth_state
       ]
-    };
+    }
   }
 
   async deleteConnection (connection_id: string): Promise<void> {
-    await this.serviceClient.DeleteConnection(connection_id, this.getUserId());
+    await this.serviceClient.DeleteConnection(connection_id, this.getUserId())
   }
 
   async getConnectionCredentials (memberGuid: string): Promise<Credential[]> {
-    this.context.updated = true;
-    this.context.current_job_id = null;
-    return await this.serviceClient.ListConnectionCredentials(memberGuid, this.getUserId());
+    this.context.updated = true
+    this.context.current_job_id = null
+    return await this.serviceClient.ListConnectionCredentials(memberGuid, this.getUserId())
   }
 
   async ResolveUserId (id: string) {
-    return await this.serviceClient?.ResolveUserId(id);
+    return await this.serviceClient?.ResolveUserId(id)
   }
 
   getUserId (): string {
-    return this.context.resolved_user_id;
+    return this.context.resolved_user_id
   }
 
   static async handleOauthResponse (provider: string, rawParams: any, rawQueries: any, body: any) {
-    let ret = {};
+    let ret = {}
     switch (provider) {
       case 'akoya':
       case 'akoya_sandbox':
-        ret = await AkoyaApi.HandleOauthResponse({ ...rawQueries, ...rawParams });
-        break;
+        ret = await AkoyaApi.HandleOauthResponse({ ...rawQueries, ...rawParams })
+        break
       case 'finicity':
       case 'finicity_sandbox':
-        ret = await FinicityApi.HandleOauthResponse({ ...rawQueries, ...rawParams, ...body });
-        break;
+        ret = await FinicityApi.HandleOauthResponse({ ...rawQueries, ...rawParams, ...body })
+        break
       case 'mx':
       case 'mx_int':
-        ret = await MxApi.HandleOauthResponse({ ...rawQueries, ...rawParams, ...body });
-        break;
+        ret = await MxApi.HandleOauthResponse({ ...rawQueries, ...rawParams, ...body })
+        break
     }
     return {
       ...ret,
       provider
-    };
+    }
   }
 
   async analytics (path: string, content: any) {
-    return await this.analyticsClient?.analytics(path.replaceAll('/', ''), content);
+    return await this.analyticsClient?.analytics(path.replaceAll('/', ''), content)
   }
 }

--- a/server/providers/mx.ts
+++ b/server/providers/mx.ts
@@ -318,7 +318,7 @@ export class MxApi implements ProviderApiClient {
       await db.set(member_guid, {
         error: true,
         error_reason
-      });
+      })
     }
     return {
       id: member_guid,

--- a/server/providers/mx.ts
+++ b/server/providers/mx.ts
@@ -1,195 +1,201 @@
 import type {
+  Challenge,
   Connection,
   CreateConnectionRequest,
   Credential,
   Institution,
-  Institutions,
   ProviderApiClient,
-  UpdateConnectionRequest,
-  VcType,
-} from '../../shared/contract';
+  UpdateConnectionRequest
+} from '../../shared/contract'
 import {
-  Challenge,
   ChallengeType,
-  ConnectionStatus,
-} from '../../shared/contract';
-import * as logger from '../infra/logger';
-import type { InstitutionResponse, CredentialResponse } from '../serviceClients/mxClient';
-import {
-  Configuration,
+  ConnectionStatus
+} from '../../shared/contract'
+import * as logger from '../infra/logger'
+import type {
+  InstitutionResponse,
   CredentialRequest,
   CredentialsResponseBody,
-  MxPlatformApiFactory,
-  MemberResponseBody,
-} from '../serviceClients/mxClient';
-import * as config from '../config';
-import { StorageClient } from'../serviceClients/storageClient';
+  MemberResponse
+} from '../serviceClients/mxClient'
+import {
+  Configuration,
+  MxPlatformApiFactory
+} from '../serviceClients/mxClient'
+import * as config from '../config'
+import { StorageClient } from '../serviceClients/storageClient'
 
-function fromMxInstitution(ins: InstitutionResponse, provider: string): Institution {
+function fromMxInstitution (ins: InstitutionResponse, provider: string): Institution {
   return {
     id: ins.code!,
-    logo_url: ins.medium_logo_url || ins.small_logo_url!,
+    logo_url: ins.medium_logo_url ?? ins.small_logo_url!,
     name: ins.name!,
     oauth: ins.supports_oauth!,
     url: ins.url!,
-    provider,
-  };
+    provider
+  }
 }
 
-function mapCredentials(mxCreds : CredentialsResponseBody) : Credential[]{
-  return mxCreds.credentials?.map(item => ({
-    id: item.guid!,
-    label: item.field_name!,
-    field_type: item.field_type!,
-    field_name: item.field_name!,
-  })) || [];
+function mapCredentials (mxCreds: CredentialsResponseBody): Credential[] {
+  if (mxCreds.credentials != null) {
+    return mxCreds.credentials.map(item => ({
+      id: item.guid!,
+      label: item.field_name!,
+      field_type: item.field_type!,
+      field_name: item.field_name!
+    }))
+  } else {
+    return []
+  }
 }
 
-function fromMxMember(mxRes: MemberResponseBody, provider: string): Connection{
-  let member = mxRes.member;
+function fromMxMember (member: MemberResponse, provider: string): Connection {
   return {
     id: member.guid!,
     cur_job_id: member.guid!,
-    //institution_code: entityId, // TODO
+    // institution_code: entityId, // TODO
     institution_code: member.institution_code, // TODO
     is_oauth: member.is_oauth,
     oauth_window_uri: member.oauth_window_uri,
-    provider,
-  };
+    provider
+  }
 }
 
 export class MxApi implements ProviderApiClient {
-  apiClient: ReturnType<typeof MxPlatformApiFactory> ;
-  mxConfig: any;
-  provider: string;
-  token: string;
-  db: StorageClient;
+  apiClient: ReturnType<typeof MxPlatformApiFactory>
+  mxConfig: any
+  provider: string
+  token: string
+  db: StorageClient
 
-  constructor(config: any, int: boolean){
-    const {mxInt, mxProd, token} = config;
-    this.token = token;
-    this.db = new StorageClient(token);
-    this.provider = int ? 'mx_int': 'mx';
-    this.mxConfig = int ? mxInt: mxProd;
+  constructor (config: any, int: boolean) {
+    const { mxInt, mxProd, token } = config
+    this.token = token
+    this.db = new StorageClient(token)
+    this.provider = int ? 'mx_int' : 'mx'
+    this.mxConfig = int ? mxInt : mxProd
     this.apiClient = MxPlatformApiFactory(new Configuration({
       ...this.mxConfig,
       baseOptions: {
         headers: {
-          Accept: 'application/vnd.mx.api.v1+json',
-        },
-      },
-    }));
-  }
-  async GetInstitutionById(id: string): Promise<Institution> {
-    const res = await this.apiClient.readInstitution(id);
-    const ins = res.data.institution!;
-    return fromMxInstitution(ins, this.provider);
+          Accept: 'application/vnd.mx.api.v1+json'
+        }
+      }
+    }))
   }
 
-  async ListInstitutionCredentials(
+  async GetInstitutionById (id: string): Promise<Institution> {
+    const res = await this.apiClient.readInstitution(id)
+    const ins = res.data.institution!
+    return fromMxInstitution(ins, this.provider)
+  }
+
+  async ListInstitutionCredentials (
     institutionId: string
-  ): Promise<Array<Credential>> {
+  ): Promise<Credential[]> {
     // console.log(this.mxConfig)
-    const res = await this.apiClient.listInstitutionCredentials(institutionId);
-    return mapCredentials(res.data);
+    const res = await this.apiClient.listInstitutionCredentials(institutionId)
+    return mapCredentials(res.data)
   }
 
-  async ListConnections(userId: string): Promise<Connection[]> {
-    const res = await this.apiClient.listMembers(userId);
-    return res.data.members.map( (m) => fromMxInstitution(m, this.provider));
+  async ListConnections (userId: string): Promise<Connection[]> {
+    const res = await this.apiClient.listMembers(userId)
+    // return res.data.members?.map((member) => fromMxInstitution(member, this.provider))
+    return res.data.members?.map((member) => fromMxMember(member, this.provider)) ?? []
   }
 
-  async ListConnectionCredentials(memberId: string, userId: string): Promise<Credential[]> {
-    const res = await this.apiClient.listMemberCredentials(memberId, userId);
-    return mapCredentials(res.data);
+  async ListConnectionCredentials (memberId: string, userId: string): Promise<Credential[]> {
+    const res = await this.apiClient.listMemberCredentials(memberId, userId)
+    return mapCredentials(res.data)
   }
 
-  async CreateConnection(
+  async CreateConnection (
     request: CreateConnectionRequest,
     userId: string
   ): Promise<Connection> {
-    const entityId = request.institution_id;
-    const existings = await this.apiClient.listMembers(userId);
-    const existing = existings.data.members.find(m => m.institution_code === entityId);
-    if(existing){
-      logger.info(`Found existing member for institution ${entityId}, deleting`);
-      await this.apiClient.deleteMember(existing.guid, userId);
+    const entityId = request.institution_id
+    const existings = await this.apiClient.listMembers(userId)
+    const existing = existings.data.members!.find(m => m.institution_code === entityId)
+    if (existing != null) {
+      logger.info(`Found existing member for institution ${entityId}, deleting`)
+      await this.apiClient.deleteMember(existing.guid!, userId)
       // return this.UpdateConnectionInternal({
       //   id: existing.guid,
       //   ...request,
       // }, userId)
     }
-    // let res = await this.apiClient.listInstitutionCredentials(entityId);
+    // let res = await this.apiClient.listInstitutionCredentials(entityId)
     // console.log(request)
     const memberRes = await this.apiClient.createMember(userId, {
-      referral_source: 'APP', //request.is_oauth ? 'APP' : '',
-      client_redirect_url: request.is_oauth ? `${config.HostUrl}/oauth/${this.provider}/redirect_from?token=${this.token}` : null,
+      referral_source: 'APP', // request.is_oauth ? 'APP' : '',
+      client_redirect_url: request.is_oauth ?? `${config.HostUrl}/oauth/${this.provider}/redirect_from?token=${this.token}`,
       member: {
-        skip_aggregation: request.skip_aggregation || request.initial_job_type === 'verify' || request.initial_job_type === 'identify',
+        skip_aggregation: request.skip_aggregation ?? (request.initial_job_type === 'verify' || request.initial_job_type === 'identify'),
         is_oauth: request.is_oauth,
         credentials: request.credentials?.map(
-          (c) => <CredentialRequest>{
-              guid: c.id,
-              value: c.value,
-            }
+          (c) => ({
+            guid: c.id,
+            value: c.value
+          } satisfies CredentialRequest)
         ),
-        institution_code: entityId,
-      },
-    } as any);
-    //console.log(memberRes)
-    const member = memberRes.data.member!;
+        institution_code: entityId
+      }
+    } as any)
+    // console.log(memberRes)
+    const member = memberRes.data.member!
     // console.log(member)
     if (request.initial_job_type === 'verify') {
-      await this.apiClient.verifyMember(member.id, userId);
+      await this.apiClient.verifyMember(member.id!, userId)
     } else if (request.initial_job_type === 'identify') {
-      await this.apiClient.identifyMember(member.id, userId);
+      await this.apiClient.identifyMember(member.id!, userId)
     }
-    return fromMxMember(memberRes.data, this.provider);
+    return fromMxMember(member, this.provider)
   }
 
-  async DeleteConnection(id: string, userId: string): Promise<void> {
-    await this.apiClient.deleteManagedMember(id, userId);
+  async DeleteConnection (id: string, userId: string): Promise<void> {
+    await this.apiClient.deleteManagedMember(id, userId)
   }
 
-  async UpdateConnection(
+  async UpdateConnection (
     request: UpdateConnectionRequest,
     userId: string
   ): Promise<Connection> {
-    const ret = await this.UpdateConnectionInternal(request, userId);
+    const ret = await this.UpdateConnectionInternal(request, userId)
     if (request.job_type === 'verify') {
-      await this.apiClient.verifyMember(request.id, userId);
+      await this.apiClient.verifyMember(request.id!, userId)
     } else if (request.job_type === 'identify') {
-      await this.apiClient.identifyMember(request.id, userId);
-    }else{
-      await this.apiClient.aggregateMember(request.id, userId);
+      await this.apiClient.identifyMember(request.id!, userId)
+    } else {
+      await this.apiClient.aggregateMember(request.id!, userId)
     }
-    return ret;
+    return ret
   }
 
-  async UpdateConnectionInternal(
+  async UpdateConnectionInternal (
     request: UpdateConnectionRequest,
     userId: string
   ): Promise<Connection> {
     const ret = await this.apiClient.updateMember(request.id!, userId, {
       member: {
-        credentials: request.credentials?.map(
-          (c) =>
-            <CredentialRequest>{
-              guid: c.id,
-              value: c.value,
-            }
-        ) || [],
-      },
-    }) ;
-    return fromMxMember(ret.data, this.provider);
+        credentials: request.credentials!.map(
+          (credential) =>
+            ({
+              guid: credential.id,
+              value: credential.value
+            } satisfies CredentialRequest)
+        )
+      }
+    })
+    const member = ret.data.member!
+    return fromMxMember(member, this.provider)
   }
 
-  async GetConnectionById(
+  async GetConnectionById (
     connectionId: string,
     userId: string
   ): Promise<Connection> {
-    const res = await this.apiClient.readMember(connectionId, userId);
-    const member = res.data.member!;
+    const res = await this.apiClient.readMember(connectionId, userId)
+    const member = res.data.member!
     return {
       id: member.guid!,
       institution_code: member.institution_code,
@@ -197,21 +203,21 @@ export class MxApi implements ProviderApiClient {
       oauth_window_uri: member.oauth_window_uri,
       provider: this.provider,
       user_id: userId
-    };
+    }
   }
 
-  async GetConnectionStatus(
+  async GetConnectionStatus (
     memberId: string,
     jobId: string,
-    single_account_select: boolean,
+    singleAccountSelect: boolean,
     userId: string
   ): Promise<Connection> {
-    const res = await this.apiClient.readMemberStatus(memberId, userId);
-    const member = res.data.member!;
-    let status = member.connection_status!;
-    const oauthStatus = await this.db.get(member.guid);
-    if(oauthStatus?.error){
-      status = ConnectionStatus[ConnectionStatus.REJECTED];
+    const res = await this.apiClient.readMemberStatus(memberId, userId)
+    const member = res.data.member!
+    let status = member.connection_status!
+    const oauthStatus = await this.db.get(member.guid)
+    if (oauthStatus?.error != null) {
+      status = ConnectionStatus[ConnectionStatus.REJECTED]
     }
     return {
       provider: this.provider,
@@ -224,91 +230,91 @@ export class MxApi implements ProviderApiClient {
       // error_reason: oauthStatus?.error_reason,
       status:
         ConnectionStatus[
-          status! as keyof typeof ConnectionStatus
+          status as keyof typeof ConnectionStatus
         ],
-      challenges: (member.challenges || []).map((item, idx) => {
-        const c: Challenge = {
-          id: item.guid || `${idx}`,
+      challenges: (member.challenges ?? []).map((item, idx) => {
+        const challenge: Challenge = {
+          id: item.guid ?? `${idx}`,
           type: ChallengeType.QUESTION,
-          question: item.label,
-        };
+          question: item.label
+        }
         switch (item.type) {
           case 'TEXT':
-            c.type = ChallengeType.QUESTION;
-            c.data = [{ key: `${idx}`, value: item.label }];
-            break;
+            challenge.type = ChallengeType.QUESTION
+            challenge.data = [{ key: `${idx}`, value: item.label }]
+            break
           case 'OPTIONS':
-            c.type = ChallengeType.OPTIONS;
-            c.question = item.label;
-            c.data = (item.options || []).map((o) => ({
-              key: o.label || o.value!,
-              value: o.value,
-            }));
-            break;
+            challenge.type = ChallengeType.OPTIONS
+            challenge.question = item.label
+            challenge.data = (item.options ?? []).map((o) => ({
+              key: o.label ?? o.value!,
+              value: o.value
+            }))
+            break
           case 'TOKEN':
-            c.type = ChallengeType.TOKEN;
-            c.data = item.label;
-            break;
+            challenge.type = ChallengeType.TOKEN
+            challenge.data = item.label!
+            break
           case 'IMAGE_DATA':
-            c.type = ChallengeType.IMAGE;
-            c.data = item.image_data;
-            break;
+            challenge.type = ChallengeType.IMAGE
+            challenge.data = item.image_data!
+            break
           case 'IMAGE_OPTIONS':
             // console.log(c)
-            c.type = ChallengeType.IMAGE_OPTIONS;
-            c.data = (item.image_options || []).map((io) => ({
-              key: io.label || io.value!,
-              value: io.data_uri || io.value,
-            }));
-            break;
+            challenge.type = ChallengeType.IMAGE_OPTIONS
+            challenge.data = (item.image_options ?? []).map((io) => ({
+              key: io.label ?? io.value!,
+              value: io.data_uri ?? io.value
+            }))
+            break
           default:
-            break; // todo?
+            break // todo?
         }
-        return c;
-      }),
-    };
+        return challenge
+      })
+    }
   }
 
-  async AnswerChallenge(
+  async AnswerChallenge (
     request: UpdateConnectionRequest,
     jobId: string,
     userId: string
   ): Promise<boolean> {
-    console.log(request);
-    const res = await this.apiClient.resumeAggregation(request.id!, userId, {
+    console.log(request)
+    await this.apiClient.resumeAggregation(request.id!, userId, {
       member: {
         challenges: request.challenges!.map((item, idx) => ({
-          guid: item.id || `${idx}`,
-          value: <string>item.response,
-        })),
-      },
-    });
-    return !!res;
+          guid: item.id ?? `${idx}`,
+          value: item.response as string
+        }))
+      }
+    })
+    return true
   }
 
-  async ResolveUserId(user_id: string){
-    logger.debug('Resolving UserId: ' + user_id);
-    let res = await this.apiClient.listUsers(1, 10, user_id);
-    const mxUser = res.data?.users?.find(u => u.id === user_id);
-    if(mxUser){
-      logger.trace(`Found existing mx user ${mxUser.guid}`);
-      return mxUser.guid;
+  async ResolveUserId (userId: string): Promise<string> {
+    logger.debug('Resolving UserId: ' + userId)
+    const res = await this.apiClient.listUsers(1, 10, userId)
+    const mxUser = res.data?.users?.find(u => u.id === userId)
+    if (mxUser != null) {
+      logger.trace(`Found existing mx user ${mxUser.guid}`)
+      return mxUser.guid!
     }
-    logger.trace(`Creating mx user ${user_id}`);
-    let ret = await this.apiClient.createUser({
-      user: {id: user_id,}
-    });
-    if(ret?.data?.user){
-      return ret.data.user.guid;
+    logger.trace(`Creating mx user ${userId}`)
+    const ret = await this.apiClient.createUser({
+      user: { id: userId }
+    })
+    if (ret?.data?.user != null) {
+      return ret.data.user.guid!
     }
-    logger.trace(`Failed creating mx user, using user_id: ${user_id}`);
-    return user_id;
+    logger.trace(`Failed creating mx user, using user_id: ${userId}`)
+    return userId
   }
 
-  static async HandleOauthResponse(request: any): Promise<Connection> {
-    const { member_guid, status, error_reason, token } = request;
-    if(status === 'error'){
-      const db = new StorageClient(token);
+  static async HandleOauthResponse (request: any): Promise<Connection> {
+    const { member_guid, status, error_reason, token } = request
+    if (status === 'error') {
+      const db = new StorageClient(token)
       await db.set(member_guid, {
         error: true,
         error_reason
@@ -316,7 +322,7 @@ export class MxApi implements ProviderApiClient {
     }
     return {
       id: member_guid,
-      status: status === 'error' ? ConnectionStatus.REJECTED : status === 'success' ? ConnectionStatus.CONNECTED : ConnectionStatus.PENDING 
-    };
+      status: status === 'error' ? ConnectionStatus.REJECTED : status === 'success' ? ConnectionStatus.CONNECTED : ConnectionStatus.PENDING
+    }
   }
 }

--- a/server/providers/sophtron.ts
+++ b/server/providers/sophtron.ts
@@ -1,41 +1,41 @@
 import {
-  Challenge,
+  type Challenge,
   ChallengeType,
-  Connection,
+  type Connection,
   ConnectionStatus,
-  CreateConnectionRequest,
-  Credential,
-  Institution,
+  type CreateConnectionRequest,
+  type Credential,
+  type Institution,
   Institutions,
-  ProviderApiClient,
-  UpdateConnectionRequest,
-  VcType,
-} from '@/../../shared/contract';
+  type ProviderApiClient,
+  type UpdateConnectionRequest,
+  VcType
+} from '@/../../shared/contract'
 
-import * as config from '../config';
-import * as logger from '../infra/logger';
-import * as http from '../infra/http';
+import * as config from '../config'
+import * as logger from '../infra/logger'
+import * as http from '../infra/http'
 
-const SophtronClient = require('../serviceClients/sophtronClient/v2');
-const SophtronVcClient = require('../serviceClients/sophtronClient/vc');
-const SophtronClientV1 = require('../serviceClients/sophtronClient');
+const SophtronClient = require('../serviceClients/sophtronClient/v2')
+const SophtronVcClient = require('../serviceClients/sophtronClient/vc')
+const SophtronClientV1 = require('../serviceClients/sophtronClient')
 
-const uuid = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const uuid = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
 
-function fromSophtronInstitution(ins: any): Institution | undefined {
+function fromSophtronInstitution (ins: any): Institution | undefined {
   if (!ins) {
-    return undefined;
+    return undefined
   }
   return {
     id: ins.InstitutionID,
     logo_url: ins.Logo,
     name: ins.InstitutionName,
     url: ins.URL,
-    provider: 'sophtron',
-  };
+    provider: 'sophtron'
+  }
 }
 
-function mapJobType(input: string){
+function mapJobType (input: string) {
   switch (input) {
     case 'agg':
     case 'aggregation':
@@ -46,116 +46,116 @@ function mapJobType(input: string){
     case 'demo':
     case 'vc_transactions':
     case 'vc_transaction':
-      return 'aggregate';
+      return 'aggregate'
     case 'all':
     case 'everything':
     case 'aggregate_all':
     case 'aggregate_everything':
     case 'agg_all':
     case 'agg_everything':
-      return 'aggregate_identity_verification';
+      return 'aggregate_identity_verification'
     case 'fullhistory':
     case 'aggregate_extendedhistory':
-      return 'aggregate_extendedhistory';
+      return 'aggregate_extendedhistory'
     case 'auth':
     case 'bankauth':
     case 'verify':
     case 'verification':
     case 'vc_account':
     case 'vc_accounts':
-      return 'verification';
+      return 'verification'
     case 'identify':
     case 'vc_identity':
-      return 'aggregate_identity';
+      return 'aggregate_identity'
     default:
       // TODO create without job?
-      logger.error(`Invalid job type ${input}`);
-      break;
+      logger.error(`Invalid job type ${input}`)
+      break
   }
 }
 
 export class SophtronApi implements ProviderApiClient {
-  apiClient: any;
-  apiClientV1: any;
-  vcClient: any;
+  apiClient: any
+  apiClientV1: any
+  vcClient: any
 
-  httpClient = http;
+  httpClient = http
 
-  constructor(config: any) {
-    let {sophtron} = config;
-    this.apiClient = new SophtronClient(sophtron);
-    this.apiClientV1 = new SophtronClientV1(sophtron);
-    this.vcClient = new SophtronVcClient(sophtron);
+  constructor (config: any) {
+    const { sophtron } = config
+    this.apiClient = new SophtronClient(sophtron)
+    this.apiClientV1 = new SophtronClientV1(sophtron)
+    this.vcClient = new SophtronVcClient(sophtron)
   }
 
-  async clearConnection(vc: any, id: string, userID: string) {
+  async clearConnection (vc: any, id: string, userID: string) {
     if (config.Demo && vc.issuer) {
       // a valid vc should have an issuer field. this means we have a successful response,
       // once a VC is sccessfully returned to user, we clear the connection for data safty
-      this.apiClient.deleteMember(userID, id);
+      this.apiClient.deleteMember(userID, id)
     }
   }
 
-  async GetInstitutionById(id: string): Promise<Institution> {
+  async GetInstitutionById (id: string): Promise<Institution> {
     // if (!uuid.test(id)) {
     //   const name = id;
     //   const res = await this.apiClient.getInstitutionsByName(name);
     //   return fromSophtronInstitution(res?.[0]);
     // }
-    const ins = await this.apiClientV1.getInstitutionById(id);
-    return fromSophtronInstitution(ins);
+    const ins = await this.apiClientV1.getInstitutionById(id)
+    return fromSophtronInstitution(ins)
   }
 
-  async ListInstitutionCredentials(id: string): Promise<Array<Credential>> {
-    const ins = await this.apiClientV1.getInstitutionById(id);
-    let ret = [
+  async ListInstitutionCredentials (id: string): Promise<Credential[]> {
+    const ins = await this.apiClientV1.getInstitutionById(id)
+    const ret = [
       {
         id: 'username',
         label: ins?.InstitutionDetail?.LoginFormUserName || 'User name',
         field_type: 'LOGIN',
         field_name: 'LOGIN'
       }
-    ];
-    if(ins?.InstitutionDetail?.LoginFormPassword !== 'None'){
+    ]
+    if (ins?.InstitutionDetail?.LoginFormPassword !== 'None') {
       ret.push({
-          id: 'password',
-          label: ins?.InstitutionDetail?.LoginFormPassword || 'Password',
-          field_type: 'PASSWORD',
-          field_name: 'PASSWORD'
-        });
+        id: 'password',
+        label: ins?.InstitutionDetail?.LoginFormPassword || 'Password',
+        field_type: 'PASSWORD',
+        field_name: 'PASSWORD'
+      })
     }
-    return ret;
+    return ret
   }
 
-  async ListConnectionCredentials(connectionId: string, userId: string): Promise<Credential[]> {
-    const uins = await this.apiClient.getMember(userId, connectionId);
-    if(uins){
-      return this.ListInstitutionCredentials(uins.InstitutionID);
+  async ListConnectionCredentials (connectionId: string, userId: string): Promise<Credential[]> {
+    const uins = await this.apiClient.getMember(userId, connectionId)
+    if (uins) {
+      return await this.ListInstitutionCredentials(uins.InstitutionID)
     }
-    return [];
+    return []
   }
 
-  ListConnections(userId: string): Promise<Connection[]> {
-    return Promise.resolve([]);
+  async ListConnections (userId: string): Promise<Connection[]> {
+    return await Promise.resolve([])
   }
 
-  async CreateConnection(
+  async CreateConnection (
     request: CreateConnectionRequest,
     userId: string
   ): Promise<Connection | undefined> {
-    let job_type = mapJobType(request.initial_job_type?.toLowerCase());
-    if(!job_type){
-      return;
+    const job_type = mapJobType(request.initial_job_type?.toLowerCase())
+    if (!job_type) {
+      return
     }
     const username = request.credentials.find(
       (item) => item.id === 'username'
-    )!.value;
+    ).value
     const passwordField = request.credentials.find(
       (item) => item.id === 'password'
-    );
+    )
     // if password field wasn't available, it should be a 'none' type
-    const password = passwordField? passwordField.value : 'None';
-    const ret = await this.apiClient.createMember(userId, job_type, username, password, request.institution_id);
+    const password = passwordField ? passwordField.value : 'None'
+    const ret = await this.apiClient.createMember(userId, job_type, username, password, request.institution_id)
     if (ret) {
       return {
         id: ret.MemberID,
@@ -163,135 +163,135 @@ export class SophtronApi implements ProviderApiClient {
         institution_code: request.institution_id, // TODO
         status: ConnectionStatus.CREATED,
         provider: 'sophtron'
-      };
+      }
     }
-    return undefined;
+    return undefined
   }
 
-  async DeleteConnection(id: string, userId: string): Promise<void> {
-    return this.apiClient.deleteMember(userId, id);
+  async DeleteConnection (id: string, userId: string): Promise<void> {
+    return this.apiClient.deleteMember(userId, id)
   }
 
-  async UpdateConnection(
+  async UpdateConnection (
     request: UpdateConnectionRequest,
     userId: string
   ): Promise<Connection> {
-    let job_type = mapJobType('agg'); //TODO
-    if(!job_type){
-      return;
+    const job_type = mapJobType('agg') // TODO
+    if (!job_type) {
+      return
     }
-    const username = request.credentials!.find(
+    const username = request.credentials.find(
       (item) => item.id === 'username'
-    )!.value;
-    const password = request.credentials!.find(
+    ).value
+    const password = request.credentials.find(
       (item) => item.id === 'password'
-    )!.value;
-    const ret = await this.apiClient.updateMember(userId, request.id, job_type, username, password);
+    ).value
+    const ret = await this.apiClient.updateMember(userId, request.id, job_type, username, password)
     return {
       id: ret.MemberID,
       cur_job_id: ret.JobID,
       institution_code: 'institution_code', // TODO
       provider: 'sophtron'
-    };
+    }
   }
 
-  async GetConnectionById(connectionId: string, userId: string): Promise<Connection> {
-    const m = await this.apiClient.getMember(userId, connectionId);
+  async GetConnectionById (connectionId: string, userId: string): Promise<Connection> {
+    const m = await this.apiClient.getMember(userId, connectionId)
     return {
       id: m.MemberID,
       institution_code: m.InstitutionID,
       provider: 'sophtron',
-      user_id: userId,
-    };
+      user_id: userId
+    }
   }
 
-  async GetConnectionStatus(memberId: string, jobId: string, single_account_select: boolean, userId: string): Promise<Connection> {
-    if(!jobId){
-      let ret = await this.GetConnectionById(memberId, userId);
-      return ret;
+  async GetConnectionStatus (memberId: string, jobId: string, single_account_select: boolean, userId: string): Promise<Connection> {
+    if (!jobId) {
+      const ret = await this.GetConnectionById(memberId, userId)
+      return ret
     }
-    const job = await this.apiClient.getJobInfo(jobId);
+    const job = await this.apiClient.getJobInfo(jobId)
     const challenge: Challenge = {
       id: '',
-      type: ChallengeType.QUESTION,
-    };
-    let status = ConnectionStatus.CHALLENGED;
-    let jobStatus = job.LastStatus;
+      type: ChallengeType.QUESTION
+    }
+    let status = ConnectionStatus.CHALLENGED
+    let jobStatus = job.LastStatus
     if (job.SuccessFlag === true) {
-      jobStatus = 'success';
+      jobStatus = 'success'
     } else if (job.SuccessFlag === false) {
-      jobStatus = 'failed';
+      jobStatus = 'failed'
     }
     switch (jobStatus) {
       case 'success':
         // case 'Completed':
-        status = ConnectionStatus.CONNECTED;
-        break;
+        status = ConnectionStatus.CONNECTED
+        break
       case 'failed':
-        status = ConnectionStatus.FAILED;
-        break;
+        status = ConnectionStatus.FAILED
+        break
       case 'AccountsReady': {
-        let jobType = job.JobType.toLowerCase();
-        if (single_account_select
-            && (!job.AccountID || job.AccountID === '00000000-0000-0000-0000-000000000000')
-            && (jobType === 'authallaccounts' || jobType === 'refreshauthall')
+        const jobType = job.JobType.toLowerCase()
+        if (single_account_select &&
+            (!job.AccountID || job.AccountID === '00000000-0000-0000-0000-000000000000') &&
+            (jobType === 'authallaccounts' || jobType === 'refreshauthall')
         ) {
-          let accounts = await this.apiClientV1.getUserInstitutionAccounts(memberId);
-          challenge.id = 'single_account_select';
-          challenge.external_id = 'single_account_select';
-          challenge.type = ChallengeType.OPTIONS;
-          challenge.question = 'Please select an account to proceed:';
+          const accounts = await this.apiClientV1.getUserInstitutionAccounts(memberId)
+          challenge.id = 'single_account_select'
+          challenge.external_id = 'single_account_select'
+          challenge.type = ChallengeType.OPTIONS
+          challenge.question = 'Please select an account to proceed:'
           challenge.data = accounts.map(
-              (a: any) => ({key: `${a.AccountName} ${a.AccountNumber}`, value: a.AccountID})
-          );
+            (a: any) => ({ key: `${a.AccountName} ${a.AccountNumber}`, value: a.AccountID })
+          )
         } else {
-          status = ConnectionStatus.CREATED;
+          status = ConnectionStatus.CREATED
         }
-        break;
+        break
       }
       default:
         if (job.SecurityQuestion) {
-          challenge.id = 'SecurityQuestion';
-          challenge.type = ChallengeType.QUESTION;
+          challenge.id = 'SecurityQuestion'
+          challenge.type = ChallengeType.QUESTION
           challenge.data = JSON.parse(job.SecurityQuestion).map(
             (q: string, i: number) => ({ key: q, value: q })
-          );
+          )
         } else if (job.TokenMethod) {
-          challenge.id = 'TokenMethod';
-          challenge.type = ChallengeType.OPTIONS;
+          challenge.id = 'TokenMethod'
+          challenge.type = ChallengeType.OPTIONS
           challenge.question =
-            'Please select a channal to receive your secure code';
+            'Please select a channal to receive your secure code'
           challenge.data = JSON.parse(job.TokenMethod).map(
             (q: string, i: number) => ({ key: q, value: q })
-          );
+          )
         } else if (job.TokenSentFlag === true) {
-          challenge.id = 'TokenSentFlag';
-          challenge.type = ChallengeType.QUESTION;
-          challenge.question = 'ota';
+          challenge.id = 'TokenSentFlag'
+          challenge.type = ChallengeType.QUESTION
+          challenge.question = 'ota'
           challenge.data = [
             {
               key: 'ota',
-              value: `Please Enter the ${job.TokenInputName || 'OTA code'}`,
-            },
-          ];
+              value: `Please Enter the ${job.TokenInputName || 'OTA code'}`
+            }
+          ]
         } else if (job.TokenRead) {
-          challenge.id = 'TokenRead';
-          challenge.type = ChallengeType.TOKEN;
+          challenge.id = 'TokenRead'
+          challenge.type = ChallengeType.TOKEN
           challenge.question =
-            'Please approve from you secure device with following token';
-          challenge.data = job.TokenRead;
+            'Please approve from you secure device with following token'
+          challenge.data = job.TokenRead
         } else if (job.CaptchaImage) {
-          challenge.id = 'CaptchaImage';
-          challenge.type = ChallengeType.IMAGE;
-          challenge.question = 'Please enter the Captcha code';
-          challenge.data = job.CaptchaImage;
+          challenge.id = 'CaptchaImage'
+          challenge.type = ChallengeType.IMAGE
+          challenge.question = 'Please enter the Captcha code'
+          challenge.data = job.CaptchaImage
           // TODO: select captcha, currently it's combined into one image and treated as a normal Captcha Image
           // challenge.type = ChallengeType.IMAGE_OPTION
           // challenge.label = ''
         } else {
-          status = ConnectionStatus.CREATED;
+          status = ConnectionStatus.CREATED
         }
-        break;
+        break
     }
     return {
       id: job.UserInstitutionID,
@@ -300,19 +300,19 @@ export class SophtronApi implements ProviderApiClient {
       status,
       challenges: challenge?.id ? [challenge] : undefined,
       provider: 'sophtron'
-    };
+    }
   }
 
-  async AnswerChallenge(request: UpdateConnectionRequest, jobId: string): Promise<boolean> {
-    const c = request.challenges![0]!;
+  async AnswerChallenge (request: UpdateConnectionRequest, jobId: string): Promise<boolean> {
+    const c = request.challenges[0]
     switch (c.type) {
       case ChallengeType.TOKEN:
-        await this.apiClientV1.jobTokenInput(jobId, null, null, true);
-        break;
+        await this.apiClientV1.jobTokenInput(jobId, null, null, true)
+        break
       case ChallengeType.IMAGE:
       case ChallengeType.IMAGE_OPTIONS:
-        await this.apiClientV1.jobCaptchaInput(jobId, c.response);
-        break;
+        await this.apiClientV1.jobCaptchaInput(jobId, c.response)
+        break
       case ChallengeType.QUESTION:
         if (c.question === 'ota' || c.id === 'TokenSentFlag') {
           await this.apiClientV1.jobTokenInput(
@@ -320,38 +320,38 @@ export class SophtronApi implements ProviderApiClient {
             null,
             c.response,
             null
-          );
+          )
         } else {
-          await this.apiClientV1.jobSecurityAnswer(jobId, [c.response]);
+          await this.apiClientV1.jobSecurityAnswer(jobId, [c.response])
         }
-        break;
+        break
       case ChallengeType.OPTIONS:
-        if(c.id === 'single_account_select'){
-          await this.apiClientV1.getFullAccountNumberWithinJob(c.response, jobId);
-        }else{
-          await this.apiClientV1.jobTokenInput(jobId, c.response, null, null);
+        if (c.id === 'single_account_select') {
+          await this.apiClientV1.getFullAccountNumberWithinJob(c.response, jobId)
+        } else {
+          await this.apiClientV1.jobTokenInput(jobId, c.response, null, null)
         }
-        break;
+        break
       default:
-        logger.error('Wrong challenge answer received', c);
-        return false;
+        logger.error('Wrong challenge answer received', c)
+        return false
     }
-    return true;
+    return true
   }
-  
-  async ResolveUserId(user_id: string){
-    logger.debug('Resolving UserId: ' + user_id);
-    const sophtronUser = await this.apiClient.getCustomerByUniqueName(user_id);
-    if(sophtronUser){
-      logger.trace(`Found existing sophtron customer ${sophtronUser.CustomerID}`);
-      return sophtronUser.CustomerID;
+
+  async ResolveUserId (user_id: string) {
+    logger.debug('Resolving UserId: ' + user_id)
+    const sophtronUser = await this.apiClient.getCustomerByUniqueName(user_id)
+    if (sophtronUser) {
+      logger.trace(`Found existing sophtron customer ${sophtronUser.CustomerID}`)
+      return sophtronUser.CustomerID
     }
-    logger.trace(`Creating sophtron user ${user_id}`);
-    let ret = await this.apiClient.createCustomer(user_id);
-    if(ret){
-      return ret.CustomerID;
+    logger.trace(`Creating sophtron user ${user_id}`)
+    const ret = await this.apiClient.createCustomer(user_id)
+    if (ret) {
+      return ret.CustomerID
     }
-    logger.trace(`Failed creating sophtron user, using user_id: ${user_id}`);
-    return user_id;
+    logger.trace(`Failed creating sophtron user, using user_id: ${user_id}`)
+    return user_id
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,41 +1,41 @@
-require('dotenv').config({ override: true });
-const express = require('express');
-const bodyParser = require('body-parser');
-const path = require('path');
-const config = require('./config');
-const http = require('./infra/http');
-const logger = require('./infra/logger');
-const useConnect = require('./connect/connectApiExpress');
-const useVcs = require('./incubationVcs/vcsServiceExpress');
-const { readFile } = require('./utils/fs');
-const RateLimit = require('express-rate-limit');
-require('express-async-errors');
+require('dotenv').config({ override: true })
+const express = require('express')
+const bodyParser = require('body-parser')
+const path = require('path')
+const config = require('./config')
+const http = require('./infra/http')
+const logger = require('./infra/logger')
+const useConnect = require('./connect/connectApiExpress')
+const useVcs = require('./incubationVcs/vcsServiceExpress')
+const { readFile } = require('./utils/fs')
+const RateLimit = require('express-rate-limit')
+require('express-async-errors')
 
 process.on('unhandledRejection', (error) => {
-  logger.error(`unhandledRejection: ${error.message}`, error);
-});
-process.removeAllListeners('warning'); // remove the noise caused by capacitor-community/http fetch plugin
-const app = express();
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+  logger.error(`unhandledRejection: ${error.message}`, error)
+})
+process.removeAllListeners('warning') // remove the noise caused by capacitor-community/http fetch plugin
+const app = express()
+app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({ extended: true }))
 
 const limiter = RateLimit({
   windowMs: 10 * 60 * 1000,
   max: 5000 // max average 500 requests per windowMs
-});
-app.use(limiter);
+})
+app.use(limiter)
 
 app.get('/ping', function (req, res) {
-  res.send('ok');
-});
+  res.send('ok')
+})
 
-useConnect(app);
+useConnect(app)
 // useVcs(app);
 app.use(function (err, req, res, next) {
-  logger.error(`Unhandled error on ${req.method} ${req.path}: `, err);
-  res.status(500);
-  res.send(err.message);
-});
+  logger.error(`Unhandled error on ${req.method} ${req.path}: `, err)
+  res.status(500)
+  res.send(err.message)
+})
 const pageQueries = new RegExp([
   'institution_id',
   'job_type',
@@ -51,42 +51,42 @@ const pageQueries = new RegExp([
   'update_credentials',
   'server',
   'is_mobile_webview'
-].map(r => `\\$${r}`).join('|'), 'g');
+].map(r => `\\$${r}`).join('|'), 'g')
 function renderDefaultPage (req, res, html) {
   if (req.query.connection_id && !req.query.provider) {
-    delete req.query.connection_id;
+    delete req.query.connection_id
   }
-  res.send(html.replaceAll(pageQueries, q => encodeURIComponent(req.query[q.substring(1)] || '')));
+  res.send(html.replaceAll(pageQueries, q => encodeURIComponent(req.query[q.substring(1)] || '')))
 }
 
 if (config.ResourcePrefix !== 'local') {
   app.get('/', function (req, res) {
-    logger.info(`serving resources from ${config.ResourcePrefix}`);
-    req.metricsPath = '/catchall';
-    const resourcePath = `${config.ResourcePrefix}${config.ResourceVersion}${req.path}`;
-    http.wget(resourcePath).then(html => { renderDefaultPage(req, res, html); });
-  });
+    logger.info(`serving resources from ${config.ResourcePrefix}`)
+    req.metricsPath = '/catchall'
+    const resourcePath = `${config.ResourcePrefix}${config.ResourceVersion}${req.path}`
+    http.wget(resourcePath).then(html => { renderDefaultPage(req, res, html) })
+  })
   app.get('*', function (req, res) {
-    logger.info(`serving resources from ${config.ResourcePrefix}`);
-    req.metricsPath = '/catchall';
-    const resourcePath = `${config.ResourcePrefix}${config.ResourceVersion}${req.path}`;
+    logger.info(`serving resources from ${config.ResourcePrefix}`)
+    req.metricsPath = '/catchall'
+    const resourcePath = `${config.ResourcePrefix}${config.ResourceVersion}${req.path}`
     if (!req.path.includes('_next/webpack-hmr')) {
-      http.stream(resourcePath, null, res);
+      http.stream(resourcePath, null, res)
     } else {
-      res.sendStatus(404);
+      res.sendStatus(404)
     }
-  });
+  })
 } else {
-  logger.info('using local resources from "../build"');
+  logger.info('using local resources from "../build"')
   app.get('/', async (req, res) => {
-    const filePath = path.join(__dirname, '../', 'build', 'index.html');
-    const html = await readFile(filePath);
-    renderDefaultPage(req, res, html);
-  });
-  app.get('*', express.static(path.join(__dirname, '../build')));
+    const filePath = path.join(__dirname, '../', 'build', 'index.html')
+    const html = await readFile(filePath)
+    renderDefaultPage(req, res, html)
+  })
+  app.get('*', express.static(path.join(__dirname, '../build')))
 }
 
 app.listen(config.Port, () => {
-  const message = `Server is running on port ${config.Port}, env: ${config.Env}`;
-  logger.info(message);
-});
+  const message = `Server is running on port ${config.Port}, env: ${config.Env}`
+  logger.info(message)
+})

--- a/server/serviceClients/akoyaClient/index.js
+++ b/server/serviceClients/akoyaClient/index.js
@@ -1,81 +1,81 @@
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const http = require('../../infra/http');
-const version = 'v2';
-const CryptoJS = require('crypto-js');
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const http = require('../../infra/http')
+const version = 'v2'
+const CryptoJS = require('crypto-js')
 
 function makeAkoyaAuthHeaders (apiConfig) {
-  const words = CryptoJS.enc.Utf8.parse(`${apiConfig.clientId}:${apiConfig.secret}`);
+  const words = CryptoJS.enc.Utf8.parse(`${apiConfig.clientId}:${apiConfig.secret}`)
   return {
     Authorization: `Basic ${CryptoJS.enc.Base64.stringify(words)}`,
     'content-type': 'application/x-www-form-urlencoded',
     accept: 'application/json'
-  };
+  }
 }
 
 function makeAkoyaBearerHeaders (token) {
   return {
     Authorization: `Bearer ${token}`,
     accept: 'application/json'
-  };
+  }
 }
 
 export default class AkoyaClient {
   constructor (apiConfig) {
-    this.apiConfig = apiConfig;
-    this.client_redirect_url = `${config.HostUrl}/oauth/${this.apiConfig.provider}/redirect_from`;
+    this.apiConfig = apiConfig
+    this.client_redirect_url = `${config.HostUrl}/oauth/${this.apiConfig.provider}/redirect_from`
     this.authParams = {
       client_id: apiConfig.clientId,
       client_secret: apiConfig.secret
-    };
+    }
   }
 
   getOauthUrl (institution_id, client_redirect_url, state) {
-    return `https://${this.apiConfig.basePath}/auth?connector=${institution_id}&client_id=${this.apiConfig.clientId}&redirect_uri=${client_redirect_url}&state=${state}&response_type=code&scope=openid email profile offline_access`;
+    return `https://${this.apiConfig.basePath}/auth?connector=${institution_id}&client_id=${this.apiConfig.clientId}&redirect_uri=${client_redirect_url}&state=${state}&response_type=code&scope=openid email profile offline_access`
   }
 
   getIdToken (authCode) {
-    const body = { grant_type: 'authorization_code', code: authCode, redirect_uri: this.client_redirect_url };
+    const body = { grant_type: 'authorization_code', code: authCode, redirect_uri: this.client_redirect_url }
     // let body = `grant_type=authorization_code&code=${authCode}`; //&redirect_uri=${this.client_redirect_url}
-    return this.post('token', body);
+    return this.post('token', body)
   }
 
   refreshToken (existingRefreshToken) {
-    return this.post('token', { grant_type: 'refresh_token', refresh_token: existingRefreshToken, client_id: this.apiConfig.clientId, client_secret: this.apiConfig.secret });
+    return this.post('token', { grant_type: 'refresh_token', refresh_token: existingRefreshToken, client_id: this.apiConfig.clientId, client_secret: this.apiConfig.secret })
   }
 
   getAccountInfo (institution_id, accountIds, token) {
     return this.get(`accounts-info/${version}/${institution_id}`, token)
-      .then(res => res.accounts);
+      .then(res => res.accounts)
   }
 
   getBalances (institution_id, token) {
-    return this.get(`balances/${version}/${institution_id}`, token);
+    return this.get(`balances/${version}/${institution_id}`, token)
   }
 
   getInvestments (institution_id, token) {
-    return this.get(`accounts/${version}/${institution_id}`, token);
+    return this.get(`accounts/${version}/${institution_id}`, token)
   }
 
   getPayments (institution_id, accountId, token) {
-    return this.get(`payments/${version}/${institution_id}/${accountId}/payment-networks`, token);
+    return this.get(`payments/${version}/${institution_id}/${accountId}/payment-networks`, token)
   }
 
   getTransactions (institution_id, accountId, token) {
-    return this.get(`transactions/${version}/${institution_id}/${accountId}?offset=0&limit=50`, token);
+    return this.get(`transactions/${version}/${institution_id}/${accountId}?offset=0&limit=50`, token)
   }
 
   getCustomerInfo (institution_id, token) {
-    return this.get(`customers/${version}/${institution_id}/current`, token);
+    return this.get(`customers/${version}/${institution_id}/current`, token)
   }
 
   post (path, body) {
-    const headers = makeAkoyaAuthHeaders(this.apiConfig);
-    return http.post(`https://${this.apiConfig.basePath}/${path}`, body, headers);
+    const headers = makeAkoyaAuthHeaders(this.apiConfig)
+    return http.post(`https://${this.apiConfig.basePath}/${path}`, body, headers)
   }
 
   get (path, token) {
-    const headers = makeAkoyaBearerHeaders(token);
-    return http.get(`https://${this.apiConfig.productPath}/${path}`, headers);
+    const headers = makeAkoyaBearerHeaders(token)
+    return http.get(`https://${this.apiConfig.productPath}/${path}`, headers)
   }
 }

--- a/server/serviceClients/analyticsClient/index.js
+++ b/server/serviceClients/analyticsClient/index.js
@@ -1,1 +1,1 @@
-export * from './ucp';
+export * from './ucp'

--- a/server/serviceClients/analyticsClient/sophtron.js
+++ b/server/serviceClients/analyticsClient/sophtron.js
@@ -1,22 +1,22 @@
-import { buildSophtronAuthCode } from '../../utils';
+import { buildSophtronAuthCode } from '../../utils'
 
-const http = require('../../infra/http');
-const config = require('../../config');
+const http = require('../../infra/http')
+const config = require('../../config')
 
 export class AnalyticsClient {
-  token;
+  token
   constructor (token) {
-    this.token = token;
+    this.token = token
   }
 
   async analytics (type, data) {
-    const ret = this.post(`${config.AnalyticsServiceEndpoint}${config.ServiceName}/${type}`, data);
-    return await ret;
+    const ret = this.post(`${config.AnalyticsServiceEndpoint}${config.ServiceName}/${type}`, data)
+    return await ret
   }
 
   async post (path, data) {
-    const phrase = buildSophtronAuthCode('get', path, config.SophtronClientId, config.SophtronClientSecret);
-    const ret = await http.post(config.AnalyticsServiceEndpoint + path, data, { Authorization: phrase, IntegrationKey: this.token });
-    return ret;
+    const phrase = buildSophtronAuthCode('get', path, config.SophtronClientId, config.SophtronClientSecret)
+    const ret = await http.post(config.AnalyticsServiceEndpoint + path, data, { Authorization: phrase, IntegrationKey: this.token })
+    return ret
   }
 }

--- a/server/serviceClients/analyticsClient/ucp.js
+++ b/server/serviceClients/analyticsClient/ucp.js
@@ -1,19 +1,19 @@
-const http = require('../../infra/http');
-const config = require('../../config');
+const http = require('../../infra/http')
+const config = require('../../config')
 
 export class AnalyticsClient {
-  token;
+  token
   constructor (token) {
-    this.token = token;
+    this.token = token
   }
 
   async analytics (type, data) {
-    const ret = this.post(`${config.ServiceName}/${type}`, data);
-    return await ret;
+    const ret = this.post(`${config.ServiceName}/${type}`, data)
+    return await ret
   }
 
   async post (path, data) {
-    const ret = await http.post(config.AnalyticsServiceEndpoint + path, data, { Authorization: `token ${this.token}` });
-    return ret;
+    const ret = await http.post(config.AnalyticsServiceEndpoint + path, data, { Authorization: `token ${this.token}` })
+    return ret
   }
 }

--- a/server/serviceClients/authClient/index.js
+++ b/server/serviceClients/authClient/index.js
@@ -1,1 +1,1 @@
-export * from './ucp';
+export * from './ucp'

--- a/server/serviceClients/authClient/sophtron.js
+++ b/server/serviceClients/authClient/sophtron.js
@@ -1,28 +1,28 @@
-import { buildSophtronAuthCode, decrypt } from '../../utils';
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const http = require('../../infra/http');
+import { buildSophtronAuthCode, decrypt } from '../../utils'
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const http = require('../../infra/http')
 
 export class AuthClient {
-  token;
+  token
   constructor (token) {
-    this.token = token;
+    this.token = token
   }
 
   async getSecretExchange (iv) {
-    const encrypted = await this.get(`/v2/secretexchange?key=${this.token}`);
-    const arr = encrypted.split('#');
-    const secret = arr.length === 2 ? arr[0] : config.SophtronClientSecret;
+    const encrypted = await this.get(`/v2/secretexchange?key=${this.token}`)
+    const arr = encrypted.split('#')
+    const secret = arr.length === 2 ? arr[0] : config.SophtronClientSecret
 
-    const uuid = Buffer.from(secret, 'base64').toString('utf-8');
-    const key = Buffer.from(uuid.replaceAll('-', '')).toString('hex');
-    const configStr = decrypt(arr.length === 2 ? arr[1] : encrypted, key, iv);
-    return JSON.parse(configStr);
+    const uuid = Buffer.from(secret, 'base64').toString('utf-8')
+    const key = Buffer.from(uuid.replaceAll('-', '')).toString('hex')
+    const configStr = decrypt(arr.length === 2 ? arr[1] : encrypted, key, iv)
+    return JSON.parse(configStr)
   }
 
   async get (path) {
-    const phrase = buildSophtronAuthCode('get', path, config.SophtronClientId, config.SophtronClientSecret);
-    const ret = await http.get(config.AuthServiceEndpoint + path, { Authorization: phrase, IntegrationKey: this.token });
-    return ret;
+    const phrase = buildSophtronAuthCode('get', path, config.SophtronClientId, config.SophtronClientSecret)
+    const ret = await http.get(config.AuthServiceEndpoint + path, { Authorization: phrase, IntegrationKey: this.token })
+    return ret
   }
 }

--- a/server/serviceClients/authClient/ucp.js
+++ b/server/serviceClients/authClient/ucp.js
@@ -1,28 +1,28 @@
-import { decrypt } from '../../utils';
+import { decrypt } from '../../utils'
 
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const http = require('../../infra/http');
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const http = require('../../infra/http')
 
 export class AuthClient {
-  token;
+  token
   constructor (token) {
-    this.token = token;
+    this.token = token
   }
 
   async getSecretExchange (iv) {
-    const encrypted = await this.get(`/secretexchange?key=${encodeURIComponent(this.token)}`);
-    const arr = encrypted.split('#');
-    const secret = arr.length === 2 ? arr[0] : config.UcpAuthEncryptionKey;
+    const encrypted = await this.get(`/secretexchange?key=${encodeURIComponent(this.token)}`)
+    const arr = encrypted.split('#')
+    const secret = arr.length === 2 ? arr[0] : config.UcpAuthEncryptionKey
 
-    const key = Buffer.from(secret, 'base64').toString('hex');
-    const configStr = decrypt(arr.length === 2 ? arr[1] : encrypted, key, iv);
-    return JSON.parse(configStr);
+    const key = Buffer.from(secret, 'base64').toString('hex')
+    const configStr = decrypt(arr.length === 2 ? arr[1] : encrypted, key, iv)
+    return JSON.parse(configStr)
   }
 
   async get (path) {
-    const phrase = 'basic ' + Buffer.from(`${config.UcpAuthClientId}:${config.UcpAuthClientSecret}`).toString('base64');
-    const ret = await http.get(config.AuthServiceEndpoint + path, { Authorization: phrase, token: this.token });
-    return ret;
+    const phrase = 'basic ' + Buffer.from(`${config.UcpAuthClientId}:${config.UcpAuthClientSecret}`).toString('base64')
+    const ret = await http.get(config.AuthServiceEndpoint + path, { Authorization: phrase, token: this.token })
+    return ret
   }
 }

--- a/server/serviceClients/finicityClient/index.js
+++ b/server/serviceClients/finicityClient/index.js
@@ -1,6 +1,6 @@
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const axios = require('axios');
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const axios = require('axios')
 
 function makeFinicityAuthHeaders (apiConfig, tokenRes) {
   return {
@@ -8,12 +8,12 @@ function makeFinicityAuthHeaders (apiConfig, tokenRes) {
     'Finicity-App-Token': tokenRes.token,
     'Content-Type': 'application/json',
     accept: 'application/json'
-  };
+  }
 }
 
 export default class FinicityClient {
   constructor (apiConfig) {
-    this.apiConfig = apiConfig;
+    this.apiConfig = apiConfig
   }
 
   getAuthToken () {
@@ -26,39 +26,39 @@ export default class FinicityClient {
         'Content-Type': 'application/json'
       }
     }).then(res => res.data).catch(err => {
-      logger.error('Error at finicityClient.getAuthToken', err?.response?.data);
-    });
+      logger.error('Error at finicityClient.getAuthToken', err?.response?.data)
+    })
   }
 
   async getInstitutions () {
-    return await this.get('institution/v2/institutions');
+    return await this.get('institution/v2/institutions')
   }
 
   async getInstitution (institutionId) {
-    return await this.get(`institution/v2/institutions/${institutionId}`);
+    return await this.get(`institution/v2/institutions/${institutionId}`)
   }
 
   async getCustomers () {
-    return await this.get('aggregation/v1/customers');
+    return await this.get('aggregation/v1/customers')
   }
 
   async getCustomer (unique_name) {
     return await this.get(`aggregation/v1/customers?username=${unique_name}`)
-      .then(ret => ret.customers?.[0]);
+      .then(ret => ret.customers?.[0])
   }
 
   async getCustomerAccounts (customerId) {
-    return await this.get(`aggregation/v1/customers/${customerId}/accounts`);
+    return await this.get(`aggregation/v1/customers/${customerId}/accounts`)
   }
 
   async getCustomerAccountsByInstitutionLoginId (customerId, institutionLoginId) {
     return await this.get(`aggregation/v1/customers/${customerId}/institutionLogins/${institutionLoginId}/accounts`)
-      .then(res => res.accounts);
+      .then(res => res.accounts)
   }
 
   async getAccountOwnerDetail (customerId, accountId) {
     return await this.get(`aggregation/v3/customers/${customerId}/accounts/${accountId}/owner`)
-      .then(res => res.holders?.[0]);
+      .then(res => res.holders?.[0])
   }
 
   async getAccountAchDetail (customerId, accountId) {
@@ -66,7 +66,7 @@ export default class FinicityClient {
     //   "routingNumber": "123456789",
     //   "realAccountNumber": 2345678901
     // }
-    return await this.get(`aggregation/v1/customers/${customerId}/accounts/${accountId}/details`);
+    return await this.get(`aggregation/v1/customers/${customerId}/accounts/${accountId}/details`)
   }
 
   async getTransactions (customerId, accountId, fromDate, toDate) {
@@ -76,7 +76,7 @@ export default class FinicityClient {
         toDate: Date.parse(toDate) / 1000,
         limit: 2
       }
-    );
+    )
   }
 
   async generateConnectLiteUrl (institutionId, customerId, request_id) {
@@ -90,7 +90,7 @@ export default class FinicityClient {
       webhookContentType: 'application/json'
       // 'singleUseUrl': true,
       // 'experience': 'default',
-    }).then(ret => ret.link);
+    }).then(ret => ret.link)
   }
 
   async generateConnectFixUrl (institutionLoginId, customerId, request_id) {
@@ -102,7 +102,7 @@ export default class FinicityClient {
       redirectUri: `${config.HostUrl}/oauth/${this.apiConfig.provider}/redirect_from?connection_id=${request_id}`,
       webhook: `${config.WebhookHostUrl}/webhook/${this.apiConfig.provider}/?connection_id=${request_id}`,
       webhookContentType: 'application/json'
-    }).then(ret => ret.link);
+    }).then(ret => ret.link)
   }
 
   async createCustomer (unique_name) {
@@ -113,29 +113,29 @@ export default class FinicityClient {
       // applicationId: '123456789',
       phone: '1-801-984-4200',
       email: 'myname@mycompany.com'
-    });
+    })
   }
 
   async post (path, body) {
-    return await this.request('post', path, null, body);
+    return await this.request('post', path, null, body)
   }
 
   async get (path, params) {
-    return await this.request('get', path, params);
+    return await this.request('get', path, params)
   }
 
   async del (path, params) {
-    return await this.request('delete', path, params);
+    return await this.request('delete', path, params)
   }
 
   async request (method, url, params, data) {
     if (!this.axios) {
-      const token = await this.getAuthToken();
-      const headers = makeFinicityAuthHeaders(this.apiConfig, token);
+      const token = await this.getAuthToken()
+      const headers = makeFinicityAuthHeaders(this.apiConfig, token)
       this.axios = axios.create({
         baseURL: this.apiConfig.basePath,
         headers
-      });
+      })
     }
     const ret = await this.axios.request({
       url,
@@ -145,9 +145,9 @@ export default class FinicityClient {
     })
       .then(res => res.data)
       .catch(err => {
-        const newErr = new Error(`Error at finicityClient.${method} ${url}`, err?.response?.data);
-        throw newErr;
-      });
-    return ret;
+        const newErr = new Error(`Error at finicityClient.${method} ${url}`, err?.response?.data)
+        throw newErr
+      })
+    return ret
   }
 }

--- a/server/serviceClients/mxClient/api.ts
+++ b/server/serviceClients/mxClient/api.ts
@@ -1,4 +1,3 @@
-/* tslint:disable */
 /* eslint-disable */
 /**
  * MX Platform API

--- a/server/serviceClients/mxClient/base.ts
+++ b/server/serviceClients/mxClient/base.ts
@@ -1,4 +1,3 @@
-/* tslint:disable */
 /* eslint-disable */
 /**
  * MX Platform API

--- a/server/serviceClients/mxClient/common.ts
+++ b/server/serviceClients/mxClient/common.ts
@@ -1,4 +1,3 @@
-/* tslint:disable */
 /* eslint-disable */
 /**
  * MX Platform API

--- a/server/serviceClients/mxClient/configuration.ts
+++ b/server/serviceClients/mxClient/configuration.ts
@@ -1,4 +1,3 @@
-/* tslint:disable */
 /* eslint-disable */
 /**
  * MX Platform API

--- a/server/serviceClients/mxClient/index.ts
+++ b/server/serviceClients/mxClient/index.ts
@@ -1,4 +1,3 @@
-/* tslint:disable */
 /* eslint-disable */
 /**
  * MX Platform API

--- a/server/serviceClients/searchClient/index.js
+++ b/server/serviceClients/searchClient/index.js
@@ -1,1 +1,1 @@
-export * from './ucp';
+export * from './ucp'

--- a/server/serviceClients/searchClient/sophtron.js
+++ b/server/serviceClients/searchClient/sophtron.js
@@ -1,15 +1,15 @@
-const http = require('../../infra/http');
-const config = require('../../config');
+const http = require('../../infra/http')
+const config = require('../../config')
 
 export class SearchClient {
   async institutions (name) {
-    const url = `${config.SearchEndpoint}institutions?query=${encodeURIComponent(name || '')}&partner=${config.OrgName}`;
+    const url = `${config.SearchEndpoint}institutions?query=${encodeURIComponent(name || '')}&partner=${config.OrgName}`
     // return this.get(url)
-    return http.wget(url);
+    return http.wget(url)
   }
 
   resolve (id) {
     // return this.get(`${config.SophtronSearchEndpoint}institution/resolve?id=${id}&partner=${config.OrgName}`)
-    return http.wget(`${config.SearchEndpoint}institution/resolve?id=${id}&partner=${config.OrgName}`);
+    return http.wget(`${config.SearchEndpoint}institution/resolve?id=${id}&partner=${config.OrgName}`)
   }
 }

--- a/server/serviceClients/searchClient/ucp.js
+++ b/server/serviceClients/searchClient/ucp.js
@@ -1,20 +1,20 @@
-const http = require('../../infra/http');
-const config = require('../../config');
+const http = require('../../infra/http')
+const config = require('../../config')
 
-export class SearchClient{
-  token;
-  
-  constructor(token){
-    this.token = token;
+export class SearchClient {
+  token
+
+  constructor (token) {
+    this.token = token
   }
 
-  async institutions(name, providers){
-    providers = providers || [];
-    let url = `${config.SearchEndpoint}institutions?query=${encodeURIComponent(name || '')}&providers=${providers.join(';')}`;
-    return http.get(url, {Authorization: `token ${this.token}`});
+  async institutions (name, providers) {
+    providers = providers || []
+    const url = `${config.SearchEndpoint}institutions?query=${encodeURIComponent(name || '')}&providers=${providers.join(';')}`
+    return http.get(url, { Authorization: `token ${this.token}` })
   }
 
-  resolve(id){
-    return http.get(`${config.SearchEndpoint}institution/resolve?id=${id}`, {Authorization: `token ${this.token}`});
+  resolve (id) {
+    return http.get(`${config.SearchEndpoint}institution/resolve?id=${id}`, { Authorization: `token ${this.token}` })
   }
 }

--- a/server/serviceClients/sophtronClient/base.js
+++ b/server/serviceClients/sophtronClient/base.js
@@ -1,12 +1,12 @@
-import { buildSophtronAuthCode } from '../../utils';
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const http = require('../../infra/http');
+import { buildSophtronAuthCode } from '../../utils'
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const http = require('../../infra/http')
 
 module.exports = class SophtronBaseClient {
-  apiConfig;
+  apiConfig
   constructor (apiConfig) {
-    this.apiConfig = apiConfig;
+    this.apiConfig = apiConfig
   }
 
   getAuthHeaders (method, path) {
@@ -20,30 +20,30 @@ module.exports = class SophtronBaseClient {
     // }
     return {
       Authorization: buildSophtronAuthCode(method, path, this.apiConfig.clientId, this.apiConfig.secret)
-    };
+    }
   }
 
   async post (path, data) {
-    const authHeader = this.getAuthHeaders('post', path);
-    const ret = await http.post(this.apiConfig.endpoint + path, data, authHeader);
-    return ret;
+    const authHeader = this.getAuthHeaders('post', path)
+    const ret = await http.post(this.apiConfig.endpoint + path, data, authHeader)
+    return ret
   }
 
   async get (path) {
-    const authHeader = this.getAuthHeaders('get', path);
-    const ret = await http.get(this.apiConfig.endpoint + path, authHeader);
-    return ret;
+    const authHeader = this.getAuthHeaders('get', path)
+    const ret = await http.get(this.apiConfig.endpoint + path, authHeader)
+    return ret
   }
 
   async put (path, data) {
-    const authHeader = this.getAuthHeaders('put', path);
-    const ret = await http.put(this.apiConfig.endpoint + path, data, authHeader);
-    return ret;
+    const authHeader = this.getAuthHeaders('put', path)
+    const ret = await http.put(this.apiConfig.endpoint + path, data, authHeader)
+    return ret
   }
 
   async del (path) {
-    const authHeader = this.getAuthHeaders('delete', path);
-    const ret = await http.del(this.apiConfig.endpoint + path, authHeader);
-    return ret;
+    const authHeader = this.getAuthHeaders('delete', path)
+    const ret = await http.del(this.apiConfig.endpoint + path, authHeader)
+    return ret
   }
-};
+}

--- a/server/serviceClients/sophtronClient/index.js
+++ b/server/serviceClients/sophtronClient/index.js
@@ -1,22 +1,22 @@
-const logger = require('../../infra/logger');
-const http = require('../../infra/http');
-const SophtronBaseClient = require('./base');
+const logger = require('../../infra/logger')
+const http = require('../../infra/http')
+const SophtronBaseClient = require('./base')
 
 module.exports = class SophtronClient extends SophtronBaseClient {
   constructor (apiConfig) {
-    super(apiConfig);
+    super(apiConfig)
   }
 
   async getUserIntegrationKey () {
-    const data = { Id: this.apiConfig.clientId };
-    const ret = await this.post('/User/GetUserIntegrationKey', data);
-    return ret;
+    const data = { Id: this.apiConfig.clientId }
+    const ret = await this.post('/User/GetUserIntegrationKey', data)
+    return ret
   }
 
   async getUserInstitutionById (id) {
     return await this.post('/UserInstitution/GetUserInstitutionByID', {
       UserInstitutionID: id
-    });
+    })
   }
 
   // getUserInstitutionsByUser(id) {
@@ -25,24 +25,24 @@ module.exports = class SophtronClient extends SophtronBaseClient {
   async deleteUserInstitution (id) {
     return await this.post('/UserInstitution/DeleteUserInstitution', {
       UserInstitutionID: id
-    });
+    })
   }
 
   async getUserInstitutionAccounts (userInstitutionID) {
     return await this.post('/UserInstitution/GetUserInstitutionAccounts', {
       UserInstitutionID: userInstitutionID
-    });
+    })
   }
 
   async getInstitutionById (id) {
-    const data = { InstitutionID: id };
-    return await this.post('/Institution/GetInstitutionByID', data);
+    const data = { InstitutionID: id }
+    return await this.post('/Institution/GetInstitutionByID', data)
   }
 
   async getInstitutionByRoutingNumber (number) {
     return await this.post('/Institution/GetInstitutionByRoutingNumber', {
       RoutingNumber: number
-    });
+    })
   }
 
   async getInstitutionsByName (name) {
@@ -52,27 +52,27 @@ module.exports = class SophtronClient extends SophtronBaseClient {
         InstitutionName: name,
         Extensive: true,
         InstitutionType: 'All'
-      });
+      })
       if (data?.length > 0) {
         return data
           .sort((a, b) => a.InstitutionName.length - b.InstitutionName.length)
-          .slice(0, 9);
+          .slice(0, 9)
       }
-      return data;
+      return data
     }
-    return [];
+    return []
   }
 
   async getJob (id) {
-    return await this.post('/Job/GetJobInformationByID', { JobID: id });
+    return await this.post('/Job/GetJobInformationByID', { JobID: id })
   }
 
   async jobSecurityAnswer (jobId, answer) {
     const ret = await this.post('/Job/UpdateJobSecurityAnswer', {
       JobID: jobId,
       SecurityAnswer: JSON.stringify(answer)
-    });
-    return ret === 0 ? {} : { error: 'SecurityAnswer failed' };
+    })
+    return ret === 0 ? {} : { error: 'SecurityAnswer failed' }
   }
 
   async jobTokenInput (jobId, tokenChoice, tokenInput, verifyPhoneFlag) {
@@ -81,60 +81,60 @@ module.exports = class SophtronClient extends SophtronBaseClient {
       TokenChoice: tokenChoice,
       TokenInput: tokenInput,
       VerifyPhoneFlag: verifyPhoneFlag
-    });
-    return ret === 0 ? {} : { error: 'TokenInput failed' };
+    })
+    return ret === 0 ? {} : { error: 'TokenInput failed' }
   }
 
   async jobCaptchaInput (jobId, input) {
     const ret = await this.post('/Job/UpdateJobCaptchaInput', {
       JobID: jobId,
       CaptchaInput: input
-    });
-    return ret === 0 ? {} : { error: 'Captcha failed' };
+    })
+    return ret === 0 ? {} : { error: 'Captcha failed' }
   }
 
   async createUserInstitutionWithRefresh (username, password, institutionId) {
-    const url = '/UserInstitution/CreateUserInstitutionWithRefresh';
+    const url = '/UserInstitution/CreateUserInstitutionWithRefresh'
     const data = {
       UserName: username,
       Password: password,
       InstitutionID: institutionId,
       UserID: this.apiConfig.clientId
-    };
-    return await this.post(url, data);
+    }
+    return await this.post(url, data)
   }
 
   async createUserInstitutionWithProfileInfo (username, password, institutionId) {
-    const url = '/UserInstitution/CreateUserInstitutionWithProfileInfo';
+    const url = '/UserInstitution/CreateUserInstitutionWithProfileInfo'
     const data = {
       UserName: username,
       Password: password,
       InstitutionID: institutionId,
       UserID: this.apiConfig.clientId
-    };
-    return await this.post(url, data);
+    }
+    return await this.post(url, data)
   }
 
   async createUserInstitutionWithAllPlusProfile (username, password, institutionId) {
-    const url = '/UserInstitution/CreateUserInstitutionWithAllPlusProfile';
+    const url = '/UserInstitution/CreateUserInstitutionWithAllPlusProfile'
     const data = {
       UserName: username,
       Password: password,
       InstitutionID: institutionId,
       UserID: this.apiConfig.clientId
-    };
-    return await this.post(url, data);
+    }
+    return await this.post(url, data)
   }
 
   async createUserInstitutionWithFullHistory (username, password, institutionId) {
-    const url = '/UserInstitution/CreateUserInstitutionWithFullHistory';
+    const url = '/UserInstitution/CreateUserInstitutionWithFullHistory'
     const data = {
       UserName: username,
       Password: password,
       InstitutionID: institutionId,
       UserID: this.apiConfig.clientId
-    };
-    return await this.post(url, data);
+    }
+    return await this.post(url, data)
   }
 
   async createUserInstitutionWithFullAccountNumbers (
@@ -142,58 +142,58 @@ module.exports = class SophtronClient extends SophtronBaseClient {
     password,
     institutionId
   ) {
-    const url = '/UserInstitution/CreateUserInstitutionWithFullAccountNumbers';
+    const url = '/UserInstitution/CreateUserInstitutionWithFullAccountNumbers'
     const data = {
       UserName: username,
       Password: password,
       InstitutionID: institutionId,
       UserID: this.apiConfig.clientId
-    };
-    return await this.post(url, data);
+    }
+    return await this.post(url, data)
   }
 
   async createUserInstitutionWOJob (username, password, institutionId) {
-    const url = '/UserInstitution/CreateUserInstitutionWOJob';
+    const url = '/UserInstitution/CreateUserInstitutionWOJob'
     return await this.post(url, {
       UserName: username,
       Password: password,
       InstitutionID: institutionId
-    });
+    })
   }
 
   async updateUserInstitution (username, password, userInstitutionID) {
-    const url = '/UserInstitution/UpdateUserInstitution';
+    const url = '/UserInstitution/UpdateUserInstitution'
     return await this.post(url, {
       UserName: username,
       Password: password,
       UserInstitutionID: userInstitutionID
-    });
+    })
   }
 
   async getUserInstitutionProfileInfor (userInstitutionID) {
-    const url = '/UserInstitution/GetUserInstitutionProfileInfor';
+    const url = '/UserInstitution/GetUserInstitutionProfileInfor'
     return await this.post(url, { UserInstitutionID: userInstitutionID }).then((data) => {
-      data.UserInstitutionID = userInstitutionID;
-      return data;
-    });
+      data.UserInstitutionID = userInstitutionID
+      return data
+    })
   }
 
   async refreshUserInstitution (userInstitutionID) {
-    const url = '/UserInstitution/RefreshUserInstitution';
+    const url = '/UserInstitution/RefreshUserInstitution'
     return await this.post(url, { UserInstitutionID: userInstitutionID }).then((data) => {
-      data.UserInstitutionID = userInstitutionID;
-      return data;
-    });
+      data.UserInstitutionID = userInstitutionID
+      return data
+    })
   }
 
   async getFullAccountNumberWithinJob (accountId, jobId) {
-    const url = '/UserInstitutionAccount/GetFullAccountNumberWithinJob';
-    return await this.post(url, { AccountID: accountId, JobID: jobId });
+    const url = '/UserInstitutionAccount/GetFullAccountNumberWithinJob'
+    return await this.post(url, { AccountID: accountId, JobID: jobId })
   }
 
   ping = () => {
     return http.get(
       `${this.apiConfig.endpoint}/UserInstitution/Ping`
-    );
-  };
-};
+    )
+  }
+}

--- a/server/serviceClients/sophtronClient/v2.js
+++ b/server/serviceClients/sophtronClient/v2.js
@@ -1,20 +1,20 @@
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const http = require('../../infra/http');
-const SophtronBaseClient = require('./base');
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const http = require('../../infra/http')
+const SophtronBaseClient = require('./base')
 
 module.exports = class SophtronV2Client extends SophtronBaseClient {
   constructor (apiConfig) {
-    super(apiConfig);
+    super(apiConfig)
   }
 
   async getCustomer (customerId) {
-    return await this.get(`/v2/customers/${customerId}`);
+    return await this.get(`/v2/customers/${customerId}`)
   }
 
   async getCustomerByUniqueName (unique_name) {
-    const arr = await this.get(`/v2/customers?uniqueID=${unique_name}`);
-    return arr?.[0];
+    const arr = await this.get(`/v2/customers?uniqueID=${unique_name}`)
+    return arr?.[0]
   }
 
   async createCustomer (unique_name) {
@@ -22,11 +22,11 @@ module.exports = class SophtronV2Client extends SophtronBaseClient {
       UniqueID: unique_name,
       Source: `Universal_Widget_${config.HostUrl}`,
       Name: 'UniversalWidget_Customer'
-    });
+    })
   }
 
   async getMember (customerId, memberId) {
-    return await this.get(`/v2/customers/${customerId}/members/${memberId}`);
+    return await this.get(`/v2/customers/${customerId}/members/${memberId}`)
   }
 
   async createMember (customerId, job_type, username, password, institution_id) {
@@ -34,25 +34,25 @@ module.exports = class SophtronV2Client extends SophtronBaseClient {
       UserName: username,
       Password: password,
       InstitutionID: institution_id
-    });
+    })
   }
 
   async updateMember (customerId, memberId, job_type, username, password) {
     return await this.put(`/v2/customers/${customerId}/members/${memberId}/${job_type}`, {
       UserName: username,
       Password: password
-    });
+    })
   }
 
   async refreshMember (customerId, memberId, job_type) {
-    return await this.post(`/v2/customers/${customerId}/members/${memberId}/${job_type}`);
+    return await this.post(`/v2/customers/${customerId}/members/${memberId}/${job_type}`)
   }
 
   async deleteMember (customerId, memberId) {
-    return await this.del(`/v2/customers/${customerId}/members/${memberId}`);
+    return await this.del(`/v2/customers/${customerId}/members/${memberId}`)
   }
 
   async getJobInfo (jobId) {
-    return await this.get(`/v2/job/${jobId}`);
+    return await this.get(`/v2/job/${jobId}`)
   }
-};
+}

--- a/server/serviceClients/sophtronClient/vc.js
+++ b/server/serviceClients/sophtronClient/vc.js
@@ -1,19 +1,19 @@
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const http = require('../../infra/http');
-const SophtronBaseClient = require('./base');
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const http = require('../../infra/http')
+const SophtronBaseClient = require('./base')
 
 module.exports = class SophtronVcClient extends SophtronBaseClient {
   constructor (apiConfig) {
-    super(apiConfig);
+    super(apiConfig)
   }
 
   async getVc (path, userId) {
-    const headers = { IntegrationKey: this.apiConfig.token };
+    const headers = { IntegrationKey: this.apiConfig.token }
     if (userId) {
-      headers.DidAuth = userId;
+      headers.DidAuth = userId
     }
-    const ret = await http.get(`${this.apiConfig.vcEndpoint}vc/${path}`, headers);
-    return ret;
+    const ret = await http.get(`${this.apiConfig.vcEndpoint}vc/${path}`, headers)
+    return ret
   }
-};
+}

--- a/server/serviceClients/storageClient/index.js
+++ b/server/serviceClients/storageClient/index.js
@@ -1,1 +1,1 @@
-export * from './redis';
+export * from './redis'

--- a/server/serviceClients/storageClient/redis.js
+++ b/server/serviceClients/storageClient/redis.js
@@ -1,42 +1,42 @@
-const config = require('../../config');
-const logger = require('../../infra/logger');
-const { createClient } = require('redis');
+const config = require('../../config')
+const logger = require('../../infra/logger')
+const { createClient } = require('redis')
 
 const redisClient = createClient({
   url: config.RedisServer
-});
+})
 
-const useRedis = config.Env !== 'dev' && config.Env !== 'mocked' && config.Env !== 'local';
+const useRedis = config.Env !== 'dev' && config.Env !== 'mocked' && config.Env !== 'local'
 
 if (useRedis) {
   redisClient.connect().then(() => {
-    logger.info('Redis connection established with server: ' + config.RedisServer);
-  });
+    logger.info('Redis connection established with server: ' + config.RedisServer)
+  })
 }
 
 const localCache = {
   // TODO: expiry?
-};
+}
 export class StorageClient {
-  token;
+  token
   constructor (token) {
-    this.token = token;
+    this.token = token
   }
 
   async get (key) {
-    logger.debug(`Redis get: ${key}, ready: ${redisClient.isReady}`);
+    logger.debug(`Redis get: ${key}, ready: ${redisClient.isReady}`)
     if (useRedis && redisClient.isReady) {
-      const ret = await redisClient.get(key);
-      return ret ? JSON.parse(ret) : null;
+      const ret = await redisClient.get(key)
+      return ret ? JSON.parse(ret) : null
     }
-    return await Promise.resolve(localCache[key]);
+    return await Promise.resolve(localCache[key])
   }
 
   async set (key, obj) {
-    logger.debug(`Redis set: ${key}, ready: ${redisClient.isReady}`);
+    logger.debug(`Redis set: ${key}, ready: ${redisClient.isReady}`)
     if (useRedis && redisClient.isReady) {
-      return await redisClient.set(key, JSON.stringify(obj), { EX: config.RedisCacheTimeSeconds });
+      return await redisClient.set(key, JSON.stringify(obj), { EX: config.RedisCacheTimeSeconds })
     }
-    return await Promise.resolve(localCache[key] = obj);
+    return await Promise.resolve(localCache[key] = obj)
   }
 }

--- a/server/serviceClients/storageClient/redis_mock.js
+++ b/server/serviceClients/storageClient/redis_mock.js
@@ -2,8 +2,8 @@ module.exports = {
   createClient () {
     return {
       async connect () {
-        return await Promise.resolve('mocked');
+        return await Promise.resolve('mocked')
       }
-    };
+    }
   }
-};
+}

--- a/server/utils/fs.js
+++ b/server/utils/fs.js
@@ -1,15 +1,15 @@
-const fs = require('fs');
-const fileReadCache = {};
+const fs = require('fs')
+const fileReadCache = {}
 
 async function readFile (path) {
   return await new Promise((resolve, reject) => {
     if (fileReadCache.content) {
-      const currentTime = new Date();
-      const difference = currentTime.getTime() - fileReadCache.time.getTime();
-      const resultInSeconds = Math.round(difference / 1000);
+      const currentTime = new Date()
+      const difference = currentTime.getTime() - fileReadCache.time.getTime()
+      const resultInSeconds = Math.round(difference / 1000)
       if (resultInSeconds <= 30) {
-        resolve(fileReadCache.content);
-        return;
+        resolve(fileReadCache.content)
+        return
       }
     }
     fs.readFile(
@@ -17,15 +17,15 @@ async function readFile (path) {
       'utf8',
       (err, content) => {
         if (err) {
-          reject(err);
+          reject(err)
         }
-        fileReadCache.time = new Date();
-        resolve(content);
+        fileReadCache.time = new Date()
+        resolve(content)
       }
-    );
-  });
+    )
+  })
 }
 
 module.exports = {
   readFile
-};
+}

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -1,61 +1,61 @@
-import { CryptoAlgorithm } from '../config';
-import { algo, enc } from 'crypto-js';
-import { createCipheriv, createDecipheriv } from 'crypto';
+import { CryptoAlgorithm } from '../config'
+import { algo, enc } from 'crypto-js'
+import { createCipheriv, createDecipheriv } from 'crypto'
 
 export function hmac (text, key) {
-  const hmac = algo.HMAC.create(algo.SHA256, enc.Base64.parse(key));
-  hmac.update(text);
-  return enc.Base64.stringify(hmac.finalize());
+  const hmac = algo.HMAC.create(algo.SHA256, enc.Base64.parse(key))
+  hmac.update(text)
+  return enc.Base64.stringify(hmac.finalize())
 }
 
 export function buildSophtronAuthCode (httpMethod, url, apiUserID, secret) {
-  const authPath = url.substring(url.lastIndexOf('/')).toLowerCase();
-  const text = httpMethod.toUpperCase() + '\n' + authPath;
-  const b64Sig = hmac(text, secret);
-  const authString = 'FIApiAUTH:' + apiUserID + ':' + b64Sig + ':' + authPath;
-  return authString;
+  const authPath = url.substring(url.lastIndexOf('/')).toLowerCase()
+  const text = httpMethod.toUpperCase() + '\n' + authPath
+  const b64Sig = hmac(text, secret)
+  const authString = 'FIApiAUTH:' + apiUserID + ':' + b64Sig + ':' + authPath
+  return authString
 }
 
-const algorithm = CryptoAlgorithm;
+const algorithm = CryptoAlgorithm
 
 export function encrypt (text, keyHex, ivHex) {
   if (!text) {
-    return '';
+    return ''
   }
-  const key = Buffer.from(keyHex, 'hex');
-  const iv = Buffer.from(ivHex, 'hex');
-  const cipher = createCipheriv(algorithm, key, iv);
-  let encrypted = cipher.update(text);
-  encrypted = Buffer.concat([encrypted, cipher.final()]);
-  return encrypted.toString('hex');
+  const key = Buffer.from(keyHex, 'hex')
+  const iv = Buffer.from(ivHex, 'hex')
+  const cipher = createCipheriv(algorithm, key, iv)
+  let encrypted = cipher.update(text)
+  encrypted = Buffer.concat([encrypted, cipher.final()])
+  return encrypted.toString('hex')
 }
 
 export function decrypt (text, keyHex, ivHex) {
   if (!text) {
-    return '';
+    return ''
   }
-  const key = Buffer.from(keyHex, 'hex');
-  const iv = Buffer.from(ivHex, 'hex');
-  const encryptedText = Buffer.from(text, 'hex');
-  const decipher = createDecipheriv(algorithm, key, iv);
-  let decrypted = decipher.update(encryptedText);
-  decrypted = Buffer.concat([decrypted, decipher.final()]);
-  return decrypted.toString();
+  const key = Buffer.from(keyHex, 'hex')
+  const iv = Buffer.from(ivHex, 'hex')
+  const encryptedText = Buffer.from(text, 'hex')
+  const decipher = createDecipheriv(algorithm, key, iv)
+  let decrypted = decipher.update(encryptedText)
+  decrypted = Buffer.concat([decrypted, decipher.final()])
+  return decrypted.toString()
 }
 
 export function decodeAuthToken (input) {
   try {
-    const str = Buffer.from(input, 'base64').toString('utf-8');
-    const arr = str.split(';');
+    const str = Buffer.from(input, 'base64').toString('utf-8')
+    const arr = str.split(';')
     if (arr.length !== 3) {
-      return input;
+      return input
     }
     return {
       provider: arr[0],
       token: arr[1],
       iv: arr[2]
-    };
+    }
   } catch (err) {
-    return input;
+    return input
   }
 }

--- a/shared/connect/ApiEndpoint.js
+++ b/shared/connect/ApiEndpoint.js
@@ -5,7 +5,7 @@ export const ApiEndpoints = {
   APPDATA: '/raja/data?type=master', // have
   ANALYTICS_EVENTS: '/analytics_events',
   ANALYTICS_PAGEVIEW: '/analytics_pageviews',
-  ANALYTICS_SESSION: '/analytics_sessions', // have 
+  ANALYTICS_SESSION: '/analytics_sessions', // have
   BLOCKED_ROUTING_NUMBERS: '/blocked_routing_numbers',
   BUDGETS: '/budgets',
   CATEGORIES: '/categories',
@@ -23,7 +23,7 @@ export const ApiEndpoints = {
   GOALS: '/goals',
   HEALTH_SCORES: '/health_scores',
   HOLDINGS: '/holdings',
-  INSTRUMENTATION: '/instrumentation', // have 
+  INSTRUMENTATION: '/instrumentation', // have
   JOBS: '/jobs', // investigating
   INSTITUTIONS: '/institutions', // have
   LOGOUT: '/logout',
@@ -49,10 +49,10 @@ export const ApiEndpoints = {
   SYNC_ACCOUNTS: '/members/refresh_all',
   TAGGINGS: '/taggings',
   TAGS: '/tags',
-  TRANSACTION_RULES: '/transaction_rules', // have 
+  TRANSACTION_RULES: '/transaction_rules', // have
   TRANSACTIONS: '/transactions',
   USER: '/user',
   USER_COMMUNICATION_PROFILE: '/user_communication_profile',
-  USER_FEATURES: '/user_features', // have 
-  USER_PROFILES: '/user_profiles',
-};
+  USER_FEATURES: '/user_features', // have
+  USER_PROFILES: '/user_profiles'
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,6 @@
   },
   "include": [
     "server",
-    "shared",
-    ".eslintrc.js",
     "jest.config.js"
   ],
   "exclude": ["dist", "node_modules", "./build"]


### PR DESCRIPTION
Using `standard-with-typescript` with default code style rules. The plan is enable strictNullChecks in the tsconfig.json and get all the typescript errors fixed eventually, in an attempt to make PRs more readable I think we should fix things in chunks. I added some rules to eslintrc to ignore certain errors so that we can focus on some of the bigger errors first and then come back later and remove those rules and fix the files in violation of those rules.

This PR is huge mainly because it removes semicolons because that's not included in the default ts lint style. This PR also includes typescript fixes for `server/providers/mx.ts`