### PR TITLE
Fix identify call on mx api

### DIFF
--- a/server/providers/mx.ts
+++ b/server/providers/mx.ts
@@ -145,9 +145,9 @@ export class MxApi implements ProviderApiClient {
     const member = memberRes.data.member
     // console.log(member)
     if (request.initial_job_type === 'verify') {
-      await this.apiClient.verifyMember(member.id, userId)
+      await this.apiClient.verifyMember(member.guid, userId)
     } else if (request.initial_job_type === 'identify') {
-      await this.apiClient.identifyMember(member.id, userId)
+      await this.apiClient.identifyMember(member.guid, userId)
     }
     return fromMxMember(member, this.provider)
   }


### PR DESCRIPTION
Identify call was not passing in the member guid properly