### PR TITLE
Add sequential jobs for MX to get all data

### DIFF
--- a/server/connect/connectApi.ts
+++ b/server/connect/connectApi.ts
@@ -99,7 +99,7 @@ export class ConnectApi extends ProviderApiBase {
       institution_id: memberData.institution_guid,
       is_oauth: (memberData.is_oauth ?? false),
       skip_aggregation: (memberData.skip_aggregation ?? false) && (memberData.is_oauth ?? false),
-      initial_job_type: this.context.job_type || 'agg',
+      initial_job_type: this.context.job_type ?? 'agg',
       credentials: memberData.credentials?.map(c => ({
         id: c.guid,
         value: c.value
@@ -163,7 +163,7 @@ export class ConnectApi extends ProviderApiBase {
 
   async loadMemberByGuid (memberGuid: string): Promise<MemberResponse> {
     const mfa = await this.getConnectionStatus(memberGuid)
-    if (!mfa?.institution_code) {
+    if (mfa?.institution_code == null) {
       const connection = await this.getConnection(memberGuid)
       return { member: mapConnection({ ...mfa, ...connection }) }
     }

--- a/server/connect/connectApiExpress.js
+++ b/server/connect/connectApiExpress.js
@@ -46,7 +46,7 @@ export default function (app) {
     const ret = await req.connectService.updateMember(req.body)
     res.send(ret)
   })
-  app.get(`${ApiEndpoints.MEMBERS}/:member_guid/`, async (req, res) => {
+  app.get(`${ApiEndpoints.MEMBERS}/:member_guid`, async (req, res) => {
     // res.send(require('./stubs/member.js'))
     // return;
     const ret = await req.connectService.loadMemberByGuid(req.params.member_guid)
@@ -111,6 +111,17 @@ export default function (app) {
 
   app.get(ApiEndpoints.MEMBERS, async (req, res) => {
     const ret = await req.connectService.loadMembers()
+    res.send({
+      members: ret
+    })
+  })
+
+  app.post(`${ApiEndpoints.MEMBERS}/:member_guid/identify`, async (req, res) => {
+    console.log('hitting Identify')
+    const ret = await req.connectService.updateConnection(
+      { id: req.params.member_guid, job_type: 'identify' },
+      req.context.resolved_user_id
+    )
     res.send({
       members: ret
     })

--- a/server/server.js
+++ b/server/server.js
@@ -54,8 +54,10 @@ const pageQueries = new RegExp([
   'single_account_select',
   'update_credentials',
   'server',
-  'is_mobile_webview'
+  'is_mobile_webview',
+  'include_identity'
 ].map(r => `\\$${r}`).join('|'), 'g')
+
 function renderDefaultPage (req, res, html) {
   if (req.query.connection_id != null && (req.query.provider == null || req.query.provider === '')) {
     delete req.query.connection_id

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -59,3 +59,41 @@ export function decodeAuthToken (input) {
     return input
   }
 }
+
+export function mapJobType (input) {
+  switch (input) {
+    case 'agg':
+    case 'aggregation':
+    case 'aggregate':
+    case 'add':
+    case 'utils':
+    case 'util':
+    case 'demo':
+    case 'vc_transactions':
+    case 'vc_transaction':
+      return 'aggregate'
+    case 'all':
+    case 'everything':
+    case 'aggregate_all':
+    case 'aggregate_everything':
+    case 'agg_all':
+    case 'agg_everything':
+      return 'aggregate_identity_verification'
+    case 'fullhistory':
+    case 'aggregate_extendedhistory':
+      return 'aggregate_extendedhistory'
+    case 'auth':
+    case 'bankauth':
+    case 'verify':
+    case 'verification':
+    case 'vc_account':
+    case 'vc_accounts':
+      return 'verification'
+    case 'identify':
+    case 'vc_identity':
+      return 'aggregate_identity'
+    default:
+      error('Invalid Job Type')
+      return null
+  }
+}

--- a/shared/contract.ts
+++ b/shared/contract.ts
@@ -8,6 +8,7 @@ export interface AuthRequest {
 export interface Context {
   institution_id?: string
   institution_uid?: string
+  include_identity?: boolean
   connection_id?: string
   current_job_id?: string
   user_id?: string


### PR DESCRIPTION
These updates provide a way to run jobs sequentially for MX institutions.

If you want to run all jobs [verification, identity, aggregation] then you need to run the widget in "auth" mode and add the url parameter `include_identity=true`. 

This will queue up a verification job first and then an identity job second, the identity job doesn't run until the verification job is complete. The second job (identity) will be hardcoded to include_transactions for now. A future update will likely make that optional.

### Usage
```javascript
mode = 'auth'
?include_identity=true (in the url params for the widget)
```