### PR TITLE
Updates to allow the .env to work with docker compose; other clean-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,8 @@ Env="pre" #the mocked environment will mock out your https calls as defined in m
 
 RedisServer="redis://localhost:6379"
 RedisCacheTimeSeconds="600"
+RedisPort="6379"
+
 ResourcePrefix="http://localhost:5173" #the url that serves the widget ui
 ResourceVersion=""
+ResourcePort="5173"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,10 @@
 FROM alpine:3.19.1
 ENV NODE_VERSION 20.11.1
 
-RUN apk --update --no-cache add nodejs npm wget
+RUN apk --update --no-cache add nodejs npm
 
 WORKDIR /app
 
-# Server
 COPY package.json package-lock.json tsconfig.json tsconfig.paths.json /app/
 RUN npm ci --only=production &&  \
     npm i -g ts-node
@@ -17,9 +16,7 @@ COPY ./server ./server
 COPY ./shared ./shared
 
 ENV Env prod
-ENV Port 8080
-ENV ResourcePrefix 'http://localhost:5173'
 
-EXPOSE 8080 6379
+EXPOSE ${Port}
 
 CMD ["ts-node", "server/server.js"]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This repo is a full stack application which anyone can clone and self-host as a 
 
 This repo is a full stack application which anyone can clone and self-host as a way to serve the connect widget.
 
-To get started, clone the repo, follow the steps in `Initial Setup`, below to set up your .env file, and then run the following command:
+To get started, clone the repo, follow the steps in `Initial Setup`, below to set up your .env file, and then run the following command, from the root of the project:
 
 *This assumes you have [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/) already installed.*
 ```
-docker-compose up
+docker compose --env-file .env up
 ```
 
 That's it! If you have questions, please reach out to us.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     container_name: ucw-app-server
     restart: on-failure
     healthcheck:
-      test: ["CMD", "wget", "http://server:8080/ping"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://server:${Port}/ping"]
       start_period: 5s
       interval: 20s
       timeout: 5s
@@ -17,18 +17,18 @@ services:
     networks:
       - ucw
     ports:
-      - '8080:8080'
+      - "${Port}:${Port}"
     env_file:
       - .env
     environment:
-      RedisServer: "redis://cache:6379"
-      ResourcePrefix: "http://ui:5173"
+      RedisServer: "redis://cache:${RedisPort}"
+      ResourcePrefix: "http://ui:${ResourcePort}"
 
   ui:
     container_name: ucw-app-ui
     restart: on-failure
     healthcheck:
-      test: ["CMD", "wget", "http://ui:5173"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://ui:${ResourcePort}"]
       start_period: 5s
       interval: 20s
       timeout: 5s
@@ -38,7 +38,9 @@ services:
     networks:
       - ucw
     ports:
-      - '5173:5173'
+      - "${ResourcePort}:${ResourcePort}"
+    environment:
+      ResourcePort: "${ResourcePort}"
 
   cache:
     container_name: ucw-app-cache
@@ -53,7 +55,7 @@ services:
     networks:
       - ucw
     ports:
-      - '6379:6379'
+      - "${RedisPort}:${RedisPort}"
     command: redis-server --save 20 1 --loglevel warning
     volumes:
       - cache:/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "js-logger": "^1.6.1",
         "redis": "^4.6.12",
         "stream-browserify": "^3.0.0",
-        "ts-node": "^10.9.2",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -48,6 +47,7 @@
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
         "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
       }
     },
@@ -1949,6 +1949,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1960,6 +1961,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3105,22 +3107,26 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3714,6 +3720,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3826,7 +3833,8 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5218,7 +5226,8 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5602,6 +5611,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -11174,7 +11184,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -13188,6 +13199,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -13408,6 +13420,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13589,7 +13602,8 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -13864,6 +13878,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "js-logger": "^1.6.1",
     "redis": "^4.6.12",
     "stream-browserify": "^3.0.0",
-    "ts-node": "^10.9.2",
     "uuid": "^9.0.1"
   },
   "eslintConfig": {
@@ -71,6 +70,7 @@
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   },
   "lint-staged": {

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -16,16 +16,16 @@ RUN npm run build
 FROM alpine:3.19.1 as web
 ENV NODE_VERSION 20.11.1
 
-RUN apk --update --no-cache add nodejs npm wget
+RUN apk --update --no-cache add nodejs npm
 
 WORKDIR /app
 
 COPY package.json package-lock.json vite.config.ts /app/
 RUN npm ci --only=production &&  \
-    npm i -g vite@5.2.6
+    npm i -g serve@14.2.1
 
 COPY --from=builder /app/dist /app/dist
 
-EXPOSE 5173
+EXPOSE ${ResourcePort}
 
-CMD ["npm", "run", "preview"]
+CMD ["sh", "-c", "serve -p ${ResourcePort} /app/dist"]

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />


### PR DESCRIPTION
- Moves `ts-node` from deps to devdeps
- Uses `serve` instead of `vite preview` to serve the ui. 
- Uses the `.env` for docker compose, so that the correct ports are used across the docker ecosystem. 
- Fixes an issue where the health checks were leaving files on the docker filesystem.