### PR TITLE
Update to v0.0.5-beta of ucw

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.4",
       "dependencies": {
         "@types/node": "^20.11.16",
-        "@ucp-npm/components": "^0.0.4-beta",
+        "@ucp-npm/components": "^0.0.5-beta",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitejs/plugin-react-swc": "^3.6.0",
         "react": "^16.13.1",
@@ -2416,9 +2416,9 @@
       }
     },
     "node_modules/@ucp-npm/components": {
-      "version": "0.0.4-beta",
-      "resolved": "https://registry.npmjs.org/@ucp-npm/components/-/components-0.0.4-beta.tgz",
-      "integrity": "sha512-NEfCD/xpia/r2AiIOHKXA3cTgj5jKYDQRazG+coGm7Bdf5FYtBRYSbX5fDeutokO16bhMHEaSSYe/bzbl8i5Iw==",
+      "version": "0.0.5-beta",
+      "resolved": "https://registry.npmjs.org/@ucp-npm/components/-/components-0.0.5-beta.tgz",
+      "integrity": "sha512-LoFnAFEWwaaABkEvxQdutv4t0Lu4qNtN6QMGhxEGUAtTo33tFKJKH5Nf6/NaUdRRawxhHTauna1vWqooV2iE9g==",
       "dependencies": {
         "@babel/runtime": "^7.14.6",
         "@kyper/button": "^3.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@types/node": "^20.11.16",
-    "@ucp-npm/components": "^0.0.4-beta",
+    "@ucp-npm/components": "^0.0.5-beta",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "react": "^16.13.1",


### PR DESCRIPTION
This updates the npm package of the connect widget to v0.0.5-beta, which contains updates from the original connect repo.