### PR TITLE
Ct/finicity fix

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,6 +51,9 @@ jobs:
           CYPRESS_sophtron_api_user_secret: ${{ secrets.SOPHTRON_API_USER_SECRET }}
           CYPRESS_mx_client_id: ${{ secrets.MX_CLIENT_ID }}
           CYPRESS_mx_api_secret: ${{ secrets.MX_API_SECRET }}
+          CYPRESS_finicity_partner_id: ${{ secrets.FINICITY_PARTNER_ID }}
+          CYPRESS_finicity_secret: ${{ secrets.FINICITY_SECRET }}
+          CYPRESS_finicity_app_key: ${{ secrets.FINICITY_APP_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           start: npm run ucw-app

--- a/cypress/e2e/finicity.cy.ts
+++ b/cypress/e2e/finicity.cy.ts
@@ -1,0 +1,15 @@
+describe('Should connect to an Institution through happy path', () => {
+  beforeEach(() => {
+    cy.setAuthCode()
+  })
+
+  it('Connects to Finbank profiles a', () => {
+    const authCode = Cypress.env('authCode')
+
+    cy.visit(`http://localhost:8080/?job_type=agg&auth=${authCode}`)
+    cy.findByPlaceholderText('Search').type('finbank profiles')
+    cy.findByLabelText('Add account with finbank profiles - a').first().click()
+
+    cy.findByRole('link', { name: 'Continue' }).should('exist')
+  })
+})

--- a/cypress/e2e/finicity.cy.ts
+++ b/cypress/e2e/finicity.cy.ts
@@ -8,7 +8,7 @@ describe('Should connect to an Institution through happy path', () => {
 
     cy.visit(`http://localhost:8080/?job_type=agg&auth=${authCode}`)
     cy.findByPlaceholderText('Search').type('finbank profiles')
-    cy.findByLabelText('Add account with finbank profiles - a').first().click()
+    cy.findByLabelText('Add account with finbank profiles - a').click()
 
     cy.findByRole('link', { name: 'Continue' }).should('exist')
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@babel/eslint-parser": "^7.18.2",
         "@capacitor-community/http": "^1.4.1",
+        "@ngrok/ngrok": "^1.2.0",
         "@types/express": "^4.17.21",
         "assert-browserify": "^2.0.0",
         "axios": "^1.6.8",
@@ -3176,6 +3177,221 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ngrok/ngrok": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.2.0.tgz",
+      "integrity": "sha512-KOM7lHTKzsQ8IQewgigOGynJKHQRt3z0lHyEgK63H2wq9tI47tWlxWYmrQoqWLcvPgP2JA24nXWeMf/ZE2BaZg==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@ngrok/ngrok-android-arm-eabi": "1.2.0",
+        "@ngrok/ngrok-android-arm64": "1.2.0",
+        "@ngrok/ngrok-darwin-arm64": "1.2.0",
+        "@ngrok/ngrok-darwin-universal": "1.2.0",
+        "@ngrok/ngrok-darwin-x64": "1.2.0",
+        "@ngrok/ngrok-freebsd-x64": "1.2.0",
+        "@ngrok/ngrok-linux-arm-gnueabihf": "1.2.0",
+        "@ngrok/ngrok-linux-arm64-gnu": "1.2.0",
+        "@ngrok/ngrok-linux-arm64-musl": "1.2.0",
+        "@ngrok/ngrok-linux-x64-gnu": "1.2.0",
+        "@ngrok/ngrok-linux-x64-musl": "1.2.0",
+        "@ngrok/ngrok-win32-ia32-msvc": "1.2.0",
+        "@ngrok/ngrok-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@ngrok/ngrok-android-arm-eabi": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm-eabi/-/ngrok-android-arm-eabi-1.2.0.tgz",
+      "integrity": "sha512-eGSZ443VQDfLLCef7E2GDX8oRYp+Fahr7nGeNY7nHu6bMEiYA92VpFOlpO9iF6HsyK/94NJiN3CbLJ7aMUHmJA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-android-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.2.0.tgz",
+      "integrity": "sha512-nwGcgK4OkFKNxEVu4Q4R8LR15OUvfESJIQ3gS5frMwa0r/FdHKNc5rmUfGSFhGGg+4ttiTzlEKMHW2tEp12FYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-Df0U42wYty4UnYB9Bm+bo3akIVe0lOX/ejDSCrPABK0Cf65184ZcqUu9kBabXQRag5rTq4uG7TzCGhaMXV44RQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-universal": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.2.0.tgz",
+      "integrity": "sha512-z5srpqZjQKomLBsY/b2Oc44V4BqIqE7Tn3YdsN3ucZg4yH9aFTHLiD2Ioubb/8u48mRvwsT9FqFTGlswWA8dew==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-EkH2qFoXyaZkLn2Nw5NvK1F6T3332xzTVXeJMF/oLme2K567rRHmFUfN9mUORm1snHO+Ct/uW9Tciz6+hlyTLg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-mwD1QBKsWV7J8IGYCsLvPvk6yoMpwlNsCt7d/nkrw2AQvx0UJgZw+q3YW93Ii7r392DtvmzDDO3jxlx/Gl0mXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-yvDEgCSL/EAAHV5EuAjULKZ8/P/i5UCN31oyp8x3hPIpTl2Lq9GfPfoAIvpM8segsbkXwlFPIA7FjMbNweQa2A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-fEVMO7OiLTHWRDBSCvXtLhZ8C9l9aCUBduYXqCtIRx0unczEX7/jpAAD0rq32eioNfywj30s0RZRusYdrPbDTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-3P6YRcID3A8J+uOEf6JIUFbEnaS4SM2dDxqYgjkoo5Qjjn/V3tZdMpbGzs/R6ly9eZ8vPQNI6A4mtHGmfHjaTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-geiZ4rTzTySIbLyxEkIV7aPdJ2hr3cKIGv1nN7uFzJPHPwxwRYLctyXHOrjbNLaKUcoEzuyqHVhu2/qUL9FZDg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-s4nfAUuCM2X4T+Z9RWzD3NbhEnzeTrpsQq51RNQ9JEjN6guab3FdT/Bn9nXkULJdZOPvqguHg878KmTwi8t3mA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-R4ovlTz22AuP7trn8CnzXqDrxFuStpx2657AMDSop/3yhS1hCxTqycRSQwXqhJisV5midaJY/e7YwNBmYnbUIA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-A5sIaZ3pXLWZO5ft0o4oyNWg6itCAaZ4Mln8Y/sMsx4AjAcaHqBod1J2We2jt5Et52sr5JRaDwBokz84ZUNi6A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ucw-app",
-  "version": "0.0.7-beta",
+  "version": "0.0.8-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ucw-app",
-      "version": "0.0.7-beta",
+      "version": "0.0.8-beta",
       "dependencies": {
         "@babel/eslint-parser": "^7.18.2",
         "@capacitor-community/http": "^1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@babel/preset-react": "^7.18.6",
         "@testing-library/cypress": "^10.0.1",
         "@types/jest": "^29.5.12",
+        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "babel-plugin-js-logger": "^1.0.17",
         "customize-cra": "^1.0.0",
@@ -3721,6 +3722,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
       "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "node_modules/@types/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@babel/eslint-parser": "^7.18.2",
     "@capacitor-community/http": "^1.4.1",
+    "@ngrok/ngrok": "^1.2.0",
     "@types/express": "^4.17.21",
     "assert-browserify": "^2.0.0",
     "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@babel/preset-react": "^7.18.6",
     "@testing-library/cypress": "^10.0.1",
     "@types/jest": "^29.5.12",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "babel-plugin-js-logger": "^1.0.17",
     "customize-cra": "^1.0.0",

--- a/server/connect/connectApiExpress.js
+++ b/server/connect/connectApiExpress.js
@@ -16,10 +16,12 @@ export default function (app) {
   stubs(app)
   app.use(contextHandler)
   app.use(async (req, res, next) => {
+    console.log('\n\nin initializer?\n\n')
     if (req.path === '/' || req.path.startsWith('/example') === true || req.path.startsWith('/static') === true) return next()
     req.connectService = new ConnectApi(req)
     if (await req.connectService.init() != null) {
       if (req.context.resolved_user_id == null || req.context.resolved_user_id === '') {
+        console.log('resolve user id from init')
         req.context.resolved_user_id = await req.connectService.ResolveUserId(req.context.user_id)
       }
     }
@@ -27,7 +29,9 @@ export default function (app) {
   })
 
   app.post('/analytics*', async (req, res) => {
+    console.log('analytics stuff', req.path)
     if (config.Env !== 'test' && config.AnalyticsServiceEndpoint !== '' && config.AnalyticsServiceEndpoint != null) {
+      console.log('analytics stuff part 2')
       const ret = await req.connectService.analytics(req.path, req.body)
       res.send(ret)
     } else {
@@ -176,11 +180,8 @@ export default function (app) {
 
   // This doesn't get hit by MX OAuth at all. So it only seems to be used for Finicity or nothing
   app.all('/webhook/:provider/*', async function (req, res) {
-    // console.log('hit it')
     const { provider } = req.params
-    // res.send('yolo')
     info(`received web hook at: ${req.path}`, req.query)
-    // console.log(req.body)
     const ret = await ConnectApi.handleOauthResponse(provider, req.params, req.query, req.body)
     res.send(ret)
   })

--- a/server/connect/connectApiExpress.js
+++ b/server/connect/connectApiExpress.js
@@ -174,6 +174,7 @@ export default function (app) {
     })
   })
 
+  // This doesn't get hit by MX OAuth at all. So it only seems to be used for Finicity or nothing
   app.all('/webhook/:provider/*', async function (req, res) {
     const { provider } = req.params
     info(`received web hook at: ${req.path}`, req.query)

--- a/server/connect/connectApiExpress.js
+++ b/server/connect/connectApiExpress.js
@@ -16,12 +16,10 @@ export default function (app) {
   stubs(app)
   app.use(contextHandler)
   app.use(async (req, res, next) => {
-    console.log('\n\nin initializer?\n\n')
     if (req.path === '/' || req.path.startsWith('/example') === true || req.path.startsWith('/static') === true) return next()
     req.connectService = new ConnectApi(req)
     if (await req.connectService.init() != null) {
       if (req.context.resolved_user_id == null || req.context.resolved_user_id === '') {
-        console.log('resolve user id from init')
         req.context.resolved_user_id = await req.connectService.ResolveUserId(req.context.user_id)
       }
     }
@@ -29,9 +27,7 @@ export default function (app) {
   })
 
   app.post('/analytics*', async (req, res) => {
-    console.log('analytics stuff', req.path)
     if (config.Env !== 'test' && config.AnalyticsServiceEndpoint !== '' && config.AnalyticsServiceEndpoint != null) {
-      console.log('analytics stuff part 2')
       const ret = await req.connectService.analytics(req.path, req.body)
       res.send(ret)
     } else {
@@ -178,7 +174,6 @@ export default function (app) {
     })
   })
 
-  // This doesn't get hit by MX OAuth at all. So it only seems to be used for Finicity or nothing
   app.all('/webhook/:provider/*', async function (req, res) {
     const { provider } = req.params
     info(`received web hook at: ${req.path}`, req.query)

--- a/server/connect/connectApiExpress.js
+++ b/server/connect/connectApiExpress.js
@@ -176,7 +176,9 @@ export default function (app) {
 
   // This doesn't get hit by MX OAuth at all. So it only seems to be used for Finicity or nothing
   app.all('/webhook/:provider/*', async function (req, res) {
+    // console.log('hit it')
     const { provider } = req.params
+    // res.send('yolo')
     info(`received web hook at: ${req.path}`, req.query)
     // console.log(req.body)
     const ret = await ConnectApi.handleOauthResponse(provider, req.params, req.query, req.body)

--- a/server/providers/finicity.test.ts
+++ b/server/providers/finicity.test.ts
@@ -1,0 +1,110 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/testServer'
+import { FinicityApi } from './finicity'
+import { finicityInsitutionData } from '../../test/testData/institution'
+import { FINICITY_CONNECT_LITE_URL, DELETE_CUSTOMER_PATH, READ_CUSTOMER_PATH } from '../../test/handlers'
+import { clearRedisMock, createClient, getRedisStorageObject } from '../../__mocks__/redis'
+import { ConnectionStatus } from '@/../../shared/contract'
+import { finicityReadCustomerData } from '../../test/testData/users'
+
+const token = 'testToken'
+
+const redisMock = createClient()
+
+const finicityApi = new FinicityApi({
+  finicitySandbox: {
+    partnerId: 'testPartnerId',
+    appKey: 'testAppKey',
+    secret: 'testSecret',
+    basePath: 'https://api.finicity.com',
+    provider: 'finicity_sandbox'
+  },
+  storageClient: redisMock,
+  token
+}, true)
+
+const institutionResponse = finicityInsitutionData.institution
+
+describe('finicity provider', () => {
+  describe('FinicityApi', () => {
+    describe('GetInstitutionById', () => {
+      it('gets institution data correctly', async () => {
+        expect(await finicityApi.GetInstitutionById('testId')).toEqual({
+          id: 'testId',
+          logo_url: institutionResponse.branding.icon,
+          name: institutionResponse.name,
+          oauth: true, // this is hardcoded true because finicity has an external widget we use
+          url: institutionResponse.urlHomeApp,
+          provider: 'finicity_sandbox'
+        })
+      })
+    })
+
+    describe('CreateConnection', () => {
+      afterEach(() => {
+        clearRedisMock()
+      })
+
+      it('generates object with connect lite url', async () => {
+        const response = await finicityApi.CreateConnection({
+          institution_id: 'testInstitutionId',
+          credentials: []
+        }, 'testUserId')
+
+        const expectedResponse = {
+          id: response.id,
+          is_oauth: true,
+          user_id: 'testUserId',
+          credentials: [] as any,
+          institution_code: 'testInstitutionId',
+          oauth_window_uri: FINICITY_CONNECT_LITE_URL,
+          provider: 'finicity_sandbox',
+          status: ConnectionStatus.PENDING
+        }
+
+        expect(getRedisStorageObject()[response.id]).toEqual(expectedResponse)
+        expect(response).toEqual(expectedResponse)
+      })
+    })
+
+    describe('DeleteConnection', () => {
+      it('deletes the connection', async () => {
+        let connectionDeletionAttempted = false
+        redisMock.set('testId', 'something')
+
+        server.use(http.delete(DELETE_CUSTOMER_PATH, () => {
+          connectionDeletionAttempted = true
+
+          return new HttpResponse(null, {
+            status: 200
+          })
+        }))
+
+        await finicityApi.DeleteConnection('testId', 'testUserId')
+
+        expect(connectionDeletionAttempted).toBe(true)
+        expect(getRedisStorageObject().testId).toBe(null)
+      })
+    })
+
+    describe('ResolveUserId', () => {
+      describe('when a finicity customer already exists', () => {
+        it('returns the user id of the existing customer', async () => {
+          server.use(http.get(READ_CUSTOMER_PATH, () => HttpResponse.json(finicityReadCustomerData)))
+
+          expect(await finicityApi.ResolveUserId('testUserId')).toEqual('finicityTestUser')
+        })
+      })
+
+      describe('when a finicity customer does NOT exist', () => {
+        it('creates a new customer and returns the ID', async () => {
+          server.use(http.get(READ_CUSTOMER_PATH, () => new HttpResponse(null, {
+            status: 200
+          })))
+
+          expect(await finicityApi.ResolveUserId('testUserId')).toEqual('createdFinicityUserId')
+        })
+      })
+    })
+  })
+})

--- a/server/providers/finicity.ts
+++ b/server/providers/finicity.ts
@@ -71,6 +71,7 @@ export class FinicityApi implements ProviderApiClient {
   }
 
   async DeleteConnection (id: string, userId: string): Promise<void> {
+    this.apiClient.deleteCustomer(userId)
     return await this.db.set(id, null)
   }
 

--- a/server/providers/index.ts
+++ b/server/providers/index.ts
@@ -133,6 +133,7 @@ export class ProviderApiBase {
     return []
   }
 
+  // This is not getting the logo url for any Finicity banks, needs to be fixed on search client probably. Mapping is wrong.
   async resolveInstitution (id: string): Promise<Institution> {
     this.context.updated = true
     const ret = {

--- a/server/providers/index.ts
+++ b/server/providers/index.ts
@@ -15,7 +15,7 @@ import type {
   CreateConnectionRequest,
   UpdateConnectionRequest
 } from '../../shared/contract'
-import { ConnectionStatus } from '../../shared/contract'
+import { ConnectionStatus, OAuthStatus } from '../../shared/contract'
 import { AnalyticsClient } from '../serviceClients/analyticsClient'
 import { SearchClient } from '../serviceClients/searchClient'
 import { AuthClient } from '../serviceClients/authClient'
@@ -239,9 +239,9 @@ export class ProviderApiBase {
       guid: connection_id,
       inbound_member_guid: connection_id,
       outbound_member_guid: connection_id,
-      auth_status: connection.status === ConnectionStatus.PENDING ? 1 : ConnectionStatus.CONNECTED ? 2 : 3
+      auth_status: connection.status === ConnectionStatus.PENDING ? OAuthStatus.PENDING : ConnectionStatus.CONNECTED ? OAuthStatus.COMPLETE : OAuthStatus.ERROR
     } as any
-    if (ret.auth_status === 3) {
+    if (ret.auth_status === OAuthStatus.ERROR) {
       ret.error_reason = connection.status
     }
     return { oauth_state: ret }

--- a/server/providers/mx.test.ts
+++ b/server/providers/mx.test.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw'
 import { server } from '../../test/testServer'
 import { institutionData } from '../../test/testData/institution'
 import { EXTENDED_HISTORY_NOT_SUPPORTED_MSG, MxApi } from './mx'
-import { AGGREGATE_MEMBER_PATH, ANSWER_CHALLENGE_PATH, CREATE_MEMBER_PATH, CREATE_USER_PATH, DELETE_CONNECTION_PATH, DELETE_MEMBER_PATH, EXTEND_HISTORY_PATH, INSTITUTION_BY_ID_PATH, READ_MEMBER_STATUS_PATH, UPDATE_CONNECTION_PATH, VERIFY_MEMBER_PATH } from '../../test/handlers'
+import { AGGREGATE_MEMBER_PATH, ANSWER_CHALLENGE_PATH, CREATE_MEMBER_PATH, CREATE_USER_PATH, DELETE_CONNECTION_PATH, DELETE_MEMBER_PATH, EXTEND_HISTORY_PATH, MX_INSTITUTION_BY_ID_PATH, READ_MEMBER_STATUS_PATH, UPDATE_CONNECTION_PATH, VERIFY_MEMBER_PATH } from '../../test/handlers'
 import { institutionCredentialsData } from '../../test/testData/institutionCredentials'
 import { aggregateMemberMemberData, connectionByIdMemberData, extendHistoryMemberData, identifyMemberData, memberData, membersData, memberStatusData, verifyMemberData } from '../../test/testData/members'
 import config from '../config'
@@ -78,7 +78,7 @@ describe('mx provider', () => {
       })
 
       it('uses the small logo if no medium logo', async () => {
-        server.use(http.get(INSTITUTION_BY_ID_PATH, () => HttpResponse.json({
+        server.use(http.get(MX_INSTITUTION_BY_ID_PATH, () => HttpResponse.json({
           ...institutionData,
           institution: {
             ...institutionData.institution,

--- a/server/providers/mx.ts
+++ b/server/providers/mx.ts
@@ -131,10 +131,6 @@ export class MxApi implements ProviderApiClient {
     if (existing != null) {
       logger.info(`Found existing member for institution ${entityId}, deleting`)
       await this.apiClient.deleteMember(existing.guid, userId)
-      // return this.UpdateConnectionInternal({
-      //   id: existing.guid,
-      //   ...request,
-      // }, userId)
     }
     // let res = await this.apiClient.listInstitutionCredentials(entityId)
     // console.log(request)

--- a/server/server.js
+++ b/server/server.js
@@ -113,6 +113,5 @@ process.on('SIGINT', async () => {
     console.log('Closing Ngrok tunnel')
     await ngrok.kill()
   }
-  // some other closing procedures go here
   process.exit(0)
 })

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import useConnect from './connect/connectApiExpress'
 import { readFile } from './utils/fs'
 import RateLimit from 'express-rate-limit'
 import 'express-async-errors'
+import ngrok from '@ngrok/ngrok'
 // import asyncify from 'express-asyncify'
 
 process.on('unhandledRejection', (error) => {
@@ -97,3 +98,11 @@ app.listen(config.PORT, () => {
   console.log(message)
   info(message)
 })
+
+// Ngrok is required for Finicity webhooks local and github testing
+if (['dev', 'test'].includes(config.Env)) {
+  ngrok.listen(app).then(() => {
+    config.WebhookHostUrl = app.listener.url()
+    console.log('established listener at: ' + app.listener.url())
+  })
+}

--- a/server/server.js
+++ b/server/server.js
@@ -106,3 +106,13 @@ if (['dev', 'test'].includes(config.Env)) {
     console.log('established listener at: ' + app.listener.url())
   })
 }
+
+process.on('SIGINT', async () => {
+  console.log('\nGracefully shutting down from SIGINT (Ctrl-C)')
+  if (['dev', 'test'].includes(config.Env)) {
+    console.log('Closing Ngrok tunnel')
+    await ngrok.kill()
+  }
+  // some other closing procedures go here
+  process.exit(0)
+})

--- a/server/serviceClients/finicityClient/index.js
+++ b/server/serviceClients/finicityClient/index.js
@@ -35,7 +35,8 @@ export default class FinicityClient {
   }
 
   async getInstitution (institutionId) {
-    return await this.get(`institution/v2/institutions/${institutionId}`)
+    const response = await this.get(`institution/v2/institutions/${institutionId}`)
+    return response.institution
   }
 
   async getCustomers () {
@@ -80,17 +81,21 @@ export default class FinicityClient {
   }
 
   async generateConnectLiteUrl (institutionId, customerId, requestId) {
-    return await this.post('connect/v2/generate/lite', {
-      language: 'en-US',
+    const requestBody = {
       partnerId: this.apiConfig.partnerId,
       customerId,
       institutionId,
       redirectUri: `${config.HostUrl}/oauth/${this.apiConfig.provider}/redirect_from?connection_id=${requestId}`,
-      webhook: `${config.WebhookHostUrl}/webhook/${this.apiConfig.provider}/?connection_id=${requestId}`,
-      webhookContentType: 'application/json'
+      // webhook: `${config.WebhookHostUrl}/webhook/${this.apiConfig.provider}/?connection_id=${requestId}`,
+      webhookContentType: 'application/json',
+      isWebView: true
       // 'singleUseUrl': true,
-      // 'experience': 'default',
-    }).then(ret => ret.link)
+    }
+
+    return await this.post('connect/v2/generate/lite', requestBody).then(ret => ret.link).catch(err => {
+      const newErr = new Error('Error getting Finicity Connect Lite Url', err)
+      throw newErr
+    })
   }
 
   async generateConnectFixUrl (institutionLoginId, customerId, requestId) {

--- a/server/serviceClients/finicityClient/index.js
+++ b/server/serviceClients/finicityClient/index.js
@@ -86,7 +86,7 @@ export default class FinicityClient {
       customerId,
       institutionId,
       redirectUri: `${config.HostUrl}/oauth/${this.apiConfig.provider}/redirect_from?connection_id=${requestId}`,
-      // webhook: `${config.WebhookHostUrl}/webhook/${this.apiConfig.provider}/?connection_id=${requestId}`,
+      webhook: `${config.WebhookHostUrl}/webhook/${this.apiConfig.provider}/?connection_id=${requestId}`,
       webhookContentType: 'application/json',
       isWebView: true
       // 'singleUseUrl': true,

--- a/server/serviceClients/finicityClient/index.js
+++ b/server/serviceClients/finicityClient/index.js
@@ -48,6 +48,10 @@ export default class FinicityClient {
       .then(ret => ret.customers?.[0])
   }
 
+  async deleteCustomer (id) {
+    return await this.del(`aggregation/v1/customers/${id}`)
+  }
+
   async getCustomerAccounts (customerId) {
     return await this.get(`aggregation/v1/customers/${customerId}/accounts`)
   }

--- a/shared/contract.ts
+++ b/shared/contract.ts
@@ -61,6 +61,13 @@ export enum ConnectionStatus {
   IMPAIRED,
   PENDING,
 }
+
+export enum OAuthStatus {
+  PENDING,
+  COMPLETE,
+  ERROR
+}
+
 export enum ChallengeType {
   QUESTION,
   OPTIONS,

--- a/test/handlers.ts
+++ b/test/handlers.ts
@@ -1,11 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import { BASE_PATH as MX_BASE_PATH } from '../server/serviceClients/mxClient/base'
-import { institutionData } from './testData/institution'
+import { institutionData, finicityInsitutionData } from './testData/institution'
 import { institutionCredentialsData } from './testData/institutionCredentials'
 import { aggregateMemberMemberData, connectionByIdMemberData, extendHistoryMemberData, identifyMemberData, memberData, membersData, memberStatusData, verifyMemberData } from './testData/members'
-import { createUserData, listUsersData } from './testData/users'
+import { createUserData, listUsersData, createCustomerData } from './testData/users'
 
-export const INSTITUTION_BY_ID_PATH = `${MX_BASE_PATH}/institutions/:institutionId`
+const FINICITY_BASE_PATH = 'https://api.finicity.com'
+
+export const MX_INSTITUTION_BY_ID_PATH = `${MX_BASE_PATH}/institutions/:institutionId`
+export const FINICITY_INSTITUTION_BY_ID_PATH = `${FINICITY_BASE_PATH}/institution/v2/institutions/:institutionId`
 export const INSTITUTION_CREDENTIALS_BY_ID_PATH = `${MX_BASE_PATH}/institutions/:institutionId/credentials`
 export const CONNECTIONS_BY_ID_PATH = `${MX_BASE_PATH}/users/:userId/members`
 export const CONNECTION_CREDENTIALS_PATH = `${MX_BASE_PATH}/users/:userId/members/:memberId/credentials`
@@ -22,9 +25,15 @@ export const READ_MEMBER_STATUS_PATH = `${MX_BASE_PATH}/users/:userId/members/:i
 export const ANSWER_CHALLENGE_PATH = `${MX_BASE_PATH}/users/:userId/members/:id/resume`
 export const USERS_PATH = `${MX_BASE_PATH}/users`
 export const CREATE_USER_PATH = `${MX_BASE_PATH}/users`
+export const FINICITY_AUTH_PATH = `${FINICITY_BASE_PATH}/aggregation/v2/partners/authentication`
+export const FINICITY_CONNECT_PATH = `${FINICITY_BASE_PATH}/connect/v2/generate/lite`
+export const FINICITY_CONNECT_LITE_URL = 'https://testconnect.com'
+export const DELETE_CUSTOMER_PATH = `${FINICITY_BASE_PATH}/aggregation/v1/customers/:id`
+export const READ_CUSTOMER_PATH = `${FINICITY_BASE_PATH}/aggregation/v1/customers?username=:id`
+export const CREATE_CUSTOMER_PATH = `${FINICITY_BASE_PATH}/aggregation/v2/customers/testing`
 
 const handlers = [
-  http.get(INSTITUTION_BY_ID_PATH, () => HttpResponse.json(institutionData)),
+  http.get(MX_INSTITUTION_BY_ID_PATH, () => HttpResponse.json(institutionData)),
   http.get(INSTITUTION_CREDENTIALS_BY_ID_PATH, () => HttpResponse.json(institutionCredentialsData)),
   http.get(CONNECTIONS_BY_ID_PATH, () => HttpResponse.json(membersData)),
   http.get(CONNECTION_CREDENTIALS_PATH, () => HttpResponse.json(institutionCredentialsData)),
@@ -40,7 +49,11 @@ const handlers = [
   http.get(READ_MEMBER_STATUS_PATH, () => HttpResponse.json(memberStatusData)),
   http.put(ANSWER_CHALLENGE_PATH, () => new HttpResponse(null, { status: 200 })),
   http.get(USERS_PATH, () => HttpResponse.json(listUsersData)),
-  http.post(CREATE_USER_PATH, () => HttpResponse.json(createUserData))
+  http.post(CREATE_USER_PATH, () => HttpResponse.json(createUserData)),
+  http.post(FINICITY_AUTH_PATH, () => HttpResponse.json({ token: 'testAuthToken' })),
+  http.get(FINICITY_INSTITUTION_BY_ID_PATH, () => HttpResponse.json(finicityInsitutionData)),
+  http.post(FINICITY_CONNECT_PATH, () => HttpResponse.json({ link: FINICITY_CONNECT_LITE_URL })),
+  http.post(CREATE_CUSTOMER_PATH, () => HttpResponse.json(createCustomerData))
 ]
 
 export default handlers

--- a/test/testData/institution.ts
+++ b/test/testData/institution.ts
@@ -8,3 +8,56 @@ export const institutionData = {
     url: 'testUrl'
   }
 }
+
+export const finicityInsitutionData = {
+  institution: {
+    id: 'testId',
+    name: 'FinBank',
+    voa: true,
+    voi: true,
+    stateAgg: true,
+    ach: true,
+    transAgg: true,
+    aha: false,
+    availBalance: false,
+    accountOwner: true,
+    loanPaymentDetails: false,
+    studentLoanData: false,
+    accountTypeDescription: 'Fake',
+    phone: '',
+    urlHomeApp: 'https://finbank.prod.fini.city/CCBankImageMFA/login.jsp',
+    urlLogonApp: 'https://finbank.prod.fini.city/CCBankImageMFA/login.jsp',
+    oauthEnabled: false,
+    urlForgotPassword: 'https://developer.mastercard.com/forgot-password',
+    urlOnlineRegistration: 'https://www.finicity.com/signup/',
+    class: 'testfi',
+    specialText: 'Please enter your FinBank Username and Password required for login.',
+    address: {
+      city: 'Utah',
+      state: '',
+      country: 'USA',
+      postalCode: '',
+      addressLine1: '',
+      addressLine2: ''
+    },
+    currency: 'USD',
+    email: 'finbank.ds5@finicity.com',
+    status: 'online',
+    branding: {
+      logo: 'https://prod-carpintero-branding.s3.us-west-2.amazonaws.com/101732/logo.svg',
+      alternateLogo: 'https://prod-carpintero-branding.s3.us-west-2.amazonaws.com/101732/alternateLogo.svg',
+      icon: 'https://prod-carpintero-branding.s3.us-west-2.amazonaws.com/101732/icon.svg',
+      primaryColor: '#1B3E4A',
+      tile: 'https://prod-carpintero-branding.s3.us-west-2.amazonaws.com/101732/tile.svg'
+    },
+    productionStatus: {
+      overallStatus: 'online',
+      transAgg: 'online',
+      voa: 'online',
+      voi: 'online',
+      stateAgg: 'online',
+      ach: 'online',
+      aha: 'online'
+    }
+  }
+}

--- a/test/testData/users.ts
+++ b/test/testData/users.ts
@@ -10,3 +10,15 @@ export const createUserData = {
     guid: 'createdUserGuid'
   }
 }
+
+export const finicityReadCustomerData = {
+  customers: [
+    {
+      id: 'finicityTestUser'
+    }
+  ]
+}
+
+export const createCustomerData = {
+  id: 'createdFinicityUserId'
+}


### PR DESCRIPTION
Finicity doesn't have have a way to create connections via an api so you have to create a customer via the api and then generate a widget_url with that customer. So in our app we're using the Oauth flow and webhooks to know when the connection has been made in the other window. The widget will successfully create a connection with Finicity but it's currently not returning any data properly, and Finicity probably doesn't have any VC endpoints to get the data from. This PR is just to get the connection working and write a test similar to the MX OAuth test.

The team should discuss what to do about getting Finicity data working or even if we want to support that in the MVP.