### PR TITLE
Fix issue with missing uuid types, update widget package version, update readme with better monorepo info

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -2,6 +2,10 @@
 
 See [Turborepo documentation](https://turbo.build/repo) for more details.
 
+For the most part, the way you interact with NPM and a monorepo is the same as with a normal repo. The following 
+commands remain the same, but will fire off the corresponding task for all monorepo apps/packages that have a task 
+with the same name.
+
 ### Install
 
 To install all apps and packages, run the following command from the root of the project:
@@ -25,3 +29,58 @@ To run in development mode for all apps and packages, run the following command 
 ```
 npm run dev
 ```
+
+### Test
+
+To run tests for all apps and packages, run the following command from the root of the project:
+
+```
+npm run test
+```
+
+### Lint
+
+To run linters for all apps and packages, run the following command from the root of the project:
+
+```
+npm run lint
+```
+
+To only run one app, run the following command from the root of the project:
+
+```
+npm run dev --workspace=<app>
+```
+
+_The same pattern (`--workspace=<app>`) can be used for `build`, `test`, and `lint`._ 
+
+### Add/Update dependencies
+
+Dependencies are still managed in each app's package.json file. Within the context of a monorepo, you do need to make sure 
+to target the appropriate workspace when you add/remove/update dependencies.
+
+Use the following commands to add/remove/update dependencies within each app/package's context:
+
+#### Install a package in a workspace
+
+    npm install <package> --workspace=<workspace>
+
+Example:
+
+    npm install react --workspace=ui
+
+#### Remove a package from a workspace
+
+    npm uninstall <package> --workspace=<workspace>
+
+Example:
+
+    npm uninstall react --workspace=ui
+
+#### Upgrade a package in a workspace
+
+    npm update <package> --workspace=<workspace>
+
+Example:
+
+    npm update react --workspace=ui

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -3,8 +3,10 @@
 See [Turborepo documentation](https://turbo.build/repo) for more details.
 
 For the most part, the way you interact with NPM and a monorepo is the same as with a normal repo. The following 
-commands remain the same, but will fire off the corresponding task for all monorepo apps/packages that have a task 
+commands remain the same, but will fire off the corresponding task for all monorepo apps/packages (workspace) that have a task 
 with the same name.
+
+Read more about workspaces [here](https://turbo.build/repo/docs/handbook/workspaces)
 
 ### Install
 

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -46,13 +46,13 @@ To run linters for all apps and packages, run the following command from the roo
 npm run lint
 ```
 
-To only run one app, run the following command from the root of the project:
+To only run the task for one app/package, run the following command from the root of the project:
 
 ```
-npm run dev --workspace=<app>
+npm run dev --workspace=<workspace>
 ```
 
-_The same pattern (`--workspace=<app>`) can be used for `build`, `test`, and `lint`._ 
+_The same pattern (`--workspace=<workspace>`) can be used for `build`, `test`, and `lint`._ 
 
 ### Add/Update dependencies
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Then run:
 
     docker compose push
 
-`<version>` must mach the respective versions in `./.env`, `DOCKER_IMAGE_{UI|SERVER}`. These env variables are used in
-the `./docker-compose.yml` file when building the images.
+To update the versions that are pulled/published, update the `./.env` file. Look at the `DOCKER_IMAGE_{UI|SERVER}` values. 
+These variables are used in the `./docker-compose.yml` file when building/pulling/publishing the images.
 
 ## Additional Information
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.0.11-beta",
+  "version": "0.0.12-beta",
   "packageManager": "npm@10.5.0",
   "scripts": {
     "cypress:open": "cypress open",
@@ -21,6 +21,7 @@
     "@capacitor-community/http": "^1.4.1",
     "@ngrok/ngrok": "^1.2.0",
     "@types/express": "^4.17.21",
+    "@types/uuid": "^9.0.8",
     "assert-browserify": "^2.0.0",
     "axios": "^1.6.8",
     "buffer-browserify": "^0.2.5",
@@ -61,7 +62,6 @@
     "@babel/preset-react": "^7.18.6",
     "@testing-library/cypress": "^10.0.1",
     "@types/jest": "^29.5.12",
-    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "babel-plugin-js-logger": "^1.0.17",
     "customize-cra": "^1.0.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.11-beta",
+  "version": "0.0.12-beta",
   "private": true,
   "type": "module",
   "packageManager": "npm@10.5.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@types/node": "^20.11.16",
-    "@ucp-npm/components": "^0.0.11-beta",
+    "@ucp-npm/components": "^0.0.12-beta",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "react": "^16.13.1",

--- a/docker-server.Dockerfile
+++ b/docker-server.Dockerfile
@@ -21,7 +21,6 @@ COPY . ${WRKDR}
 RUN turbo prune --scope=${APP} --docker
 
 FROM base as builder
-RUN npm i -g turbo
 ARG APP
 ARG WRKDR
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
       "version": "0.0.11-beta",
       "dependencies": {
         "@types/node": "^20.11.16",
-        "@ucp-npm/components": "^0.0.11-beta",
+        "@ucp-npm/components": "^0.0.12-beta",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitejs/plugin-react-swc": "^3.6.0",
         "react": "^16.13.1",
@@ -5424,9 +5424,9 @@
       }
     },
     "node_modules/@ucp-npm/components": {
-      "version": "0.0.11-beta",
-      "resolved": "https://registry.npmjs.org/@ucp-npm/components/-/components-0.0.11-beta.tgz",
-      "integrity": "sha512-GZ59VLgc0CABu1PwE5CaRxHbrtyTdd3AQiL5alDZHnzEnXJzy4l7tK77fXQ6aZI6FBMWIlwnIkzOtECfLT7Ylg==",
+      "version": "0.0.12-beta",
+      "resolved": "https://registry.npmjs.org/@ucp-npm/components/-/components-0.0.12-beta.tgz",
+      "integrity": "sha512-w9H8d+dC0qtCxwBzNBYyp2ONRtZf+ASWEbFlpYOPSve3F/XTclGSOcMxf8uIqqSbv5Cpk6/SM5yd8AgsLNA1JA==",
       "dependencies": {
         "@babel/runtime": "^7.14.6",
         "@kyper/button": "^3.2.0",
@@ -18134,6 +18134,7 @@
       }
     },
     "packages/eslint-config": {
+      "name": "@repo/eslint-config",
       "version": "0.0.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.1.0",
@@ -18384,6 +18385,7 @@
       }
     },
     "packages/typescript-config": {
+      "name": "@repo/typescript-config",
       "version": "0.0.0",
       "license": "MIT"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,13 @@
       }
     },
     "apps/server": {
-      "version": "0.0.11-beta",
+      "version": "0.0.12-beta",
       "dependencies": {
         "@babel/eslint-parser": "^7.18.2",
         "@capacitor-community/http": "^1.4.1",
         "@ngrok/ngrok": "^1.2.0",
         "@types/express": "^4.17.21",
+        "@types/uuid": "^9.0.8",
         "assert-browserify": "^2.0.0",
         "axios": "^1.6.8",
         "buffer-browserify": "^0.2.5",
@@ -52,7 +53,6 @@
         "@babel/preset-react": "^7.18.6",
         "@testing-library/cypress": "^10.0.1",
         "@types/jest": "^29.5.12",
-        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "babel-plugin-js-logger": "^1.0.17",
         "customize-cra": "^1.0.0",
@@ -72,7 +72,7 @@
       }
     },
     "apps/ui": {
-      "version": "0.0.11-beta",
+      "version": "0.0.12-beta",
       "dependencies": {
         "@types/node": "^20.11.16",
         "@ucp-npm/components": "^0.0.12-beta",
@@ -5064,8 +5064,7 @@
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",


### PR DESCRIPTION
Fixes an issue with `uuid` package missing types. This error was being thrown in docker. Docker Compose uses `npm i --omit=dev` so any devDeps aren't installed. Since the `@types/uuid` package was in devDeps, it was missing in the docker build, and was throwing the error.

Add more details about how to update npm packages within the context of the monorepo.