### PR TITLE
Generate user in cypress tests and use resolved id in data endpoints

### DIFF
--- a/apps/server/cypress/utils/generateVcDataTests.ts
+++ b/apps/server/cypress/utils/generateVcDataTests.ts
@@ -47,7 +47,7 @@ const verifyIdentity = ({ provider, memberGuid, userId }) => {
 const verifyTransactions = ({ accountId, provider, userId }) => {
   cy.request(
     'GET',
-    `/data/transactions?provider=${provider}&user_id=${userId}&account_id=${accountId}${provider === 'sophtron' ? '&startTime=1/1/2024&endTime=1/2/2024' : ''}`
+    `/data/transactions?provider=${provider}&user_id=${userId}&account_id=${accountId}${provider === 'sophtron' ? '&start_time=1/1/2024&end_time=1/2/2024' : ''}`
   ).should((response) => {
     expect(response.status).to.equal(200)
     expect(response.body).to.haveOwnProperty('jwt')

--- a/apps/server/src/adapters/akoya.ts
+++ b/apps/server/src/adapters/akoya.ts
@@ -1,5 +1,6 @@
 import * as logger from '../infra/logger'
 import AkoyaClient from '../providerApiClients/akoya'
+import providerCredentials from '../providerCredentials'
 import { get, set } from '../services/storageClient/redis'
 import {
   type Connection,
@@ -18,11 +19,12 @@ export class AkoyaAdapter implements WidgetAdapter {
   sandbox: boolean
   apiClient: any
   token: string
-  constructor(config: any, sandbox: boolean) {
-    const { akoyaProd, akoyaSandbox, token } = config
-    this.token = token
+  constructor(sandbox: boolean) {
+    this.token = 'thisNeverWorked'
     this.sandbox = sandbox
-    this.apiClient = new AkoyaClient(sandbox ? akoyaSandbox : akoyaProd)
+    this.apiClient = new AkoyaClient(
+      sandbox ? providerCredentials.akoyaSandbox : providerCredentials.akoyaProd
+    )
   }
 
   async GetInstitutionById(id: string): Promise<Institution> {

--- a/apps/server/src/adapters/finicity.test.ts
+++ b/apps/server/src/adapters/finicity.test.ts
@@ -11,7 +11,8 @@ import { finicityReadCustomerData } from '../test/testData/users'
 import { server } from '../test/testServer'
 import { FinicityAdapter } from './finicity'
 
-const finicityApi = new FinicityAdapter()
+const isSandbox = true
+const finicityApi = new FinicityAdapter(isSandbox)
 
 const institutionResponse = finicityInsitutionData.institution
 

--- a/apps/server/src/adapters/finicity.test.ts
+++ b/apps/server/src/adapters/finicity.test.ts
@@ -11,15 +11,7 @@ import { finicityReadCustomerData } from '../test/testData/users'
 import { server } from '../test/testServer'
 import { FinicityAdapter } from './finicity'
 
-const finicityApi = new FinicityAdapter({
-  finicityProd: {
-    partnerId: 'testPartnerId',
-    appKey: 'testAppKey',
-    secret: 'testSecret',
-    basePath: 'https://api.finicity.com',
-    provider: 'finicity_sandbox'
-  }
-})
+const finicityApi = new FinicityAdapter()
 
 const institutionResponse = finicityInsitutionData.institution
 
@@ -33,7 +25,7 @@ describe('finicity provider', () => {
           name: institutionResponse.name,
           oauth: true, // this is hardcoded true because finicity has an external widget we use
           url: institutionResponse.urlHomeApp,
-          provider: 'finicity_sandbox'
+          provider: 'finicity'
         })
       })
     })
@@ -55,7 +47,7 @@ describe('finicity provider', () => {
           credentials: [] as any,
           institution_code: 'testInstitutionId',
           oauth_window_uri: FINICITY_CONNECT_LITE_URL,
-          provider: 'finicity_sandbox',
+          provider: 'finicity',
           status: ConnectionStatus.PENDING
         }
 

--- a/apps/server/src/adapters/finicity.ts
+++ b/apps/server/src/adapters/finicity.ts
@@ -1,5 +1,6 @@
 import * as logger from '../infra/logger'
 import FinicityClient from '../providerApiClients/finicity'
+import providerCredentials from '../providerCredentials'
 import { get, set } from '../services/storageClient/redis'
 import type {
   Connection,
@@ -17,10 +18,9 @@ export class FinicityAdapter implements WidgetAdapter {
   sandbox: boolean
   apiClient: any
 
-  constructor(config: any) {
-    const { finicityProd } = config
-    this.sandbox = false
-    this.apiClient = new FinicityClient(finicityProd)
+  constructor(isSandbox = false) {
+    this.sandbox = isSandbox
+    this.apiClient = new FinicityClient(providerCredentials.finicityProd)
   }
 
   async GetInstitutionById(id: string): Promise<Institution> {
@@ -121,7 +121,7 @@ export class FinicityAdapter implements WidgetAdapter {
       return finicityUser.id
     }
     logger.trace(`Creating finicity user ${userId}`)
-    const ret = await this.apiClient.createCustomer(userId)
+    const ret = await this.apiClient.createCustomer(userId, this.sandbox)
     if (ret) {
       return ret.id
     }

--- a/apps/server/src/adapters/index.test.ts
+++ b/apps/server/src/adapters/index.test.ts
@@ -7,15 +7,8 @@ import { MxAdapter } from './mx'
 
 const testConnectionId = 'test_connection_id'
 
-const mxAdapter = new MxAdapter(
-  {
-    mxProd: {
-      username: 'testUsername',
-      password: 'testPassword'
-    }
-  },
-  false
-)
+const isIntEnv = false
+const mxAdapter = new MxAdapter(isIntEnv)
 
 const providerAdapterBase = new ProviderAdapterBase({
   context: {
@@ -47,14 +40,16 @@ describe('ProviderAdapterBase', () => {
         )
       )
 
-      expect(await providerAdapterBase.getOauthState(testConnectionId)).toEqual({
-        oauth_state: {
-          guid: 'test_connection_id',
-          inbound_member_guid: 'test_connection_id',
-          outbound_member_guid: 'test_connection_id',
-          auth_status: OAuthStatus.PENDING
+      expect(await providerAdapterBase.getOauthState(testConnectionId)).toEqual(
+        {
+          oauth_state: {
+            guid: 'test_connection_id',
+            inbound_member_guid: 'test_connection_id',
+            outbound_member_guid: 'test_connection_id',
+            auth_status: OAuthStatus.PENDING
+          }
         }
-      })
+      )
     })
 
     it('returns a connected oauth state', async () => {
@@ -69,14 +64,16 @@ describe('ProviderAdapterBase', () => {
         )
       )
 
-      expect(await providerAdapterBase.getOauthState(testConnectionId)).toEqual({
-        oauth_state: {
-          guid: 'test_connection_id',
-          inbound_member_guid: 'test_connection_id',
-          outbound_member_guid: 'test_connection_id',
-          auth_status: OAuthStatus.COMPLETE
+      expect(await providerAdapterBase.getOauthState(testConnectionId)).toEqual(
+        {
+          oauth_state: {
+            guid: 'test_connection_id',
+            inbound_member_guid: 'test_connection_id',
+            outbound_member_guid: 'test_connection_id',
+            auth_status: OAuthStatus.COMPLETE
+          }
         }
-      })
+      )
     })
 
     it('returns an errored oauth state', async () => {
@@ -91,15 +88,17 @@ describe('ProviderAdapterBase', () => {
         )
       )
 
-      expect(await providerAdapterBase.getOauthState(testConnectionId)).toEqual({
-        oauth_state: {
-          guid: 'test_connection_id',
-          inbound_member_guid: 'test_connection_id',
-          outbound_member_guid: 'test_connection_id',
-          auth_status: OAuthStatus.ERROR,
-          error_reason: ConnectionStatus.DENIED
+      expect(await providerAdapterBase.getOauthState(testConnectionId)).toEqual(
+        {
+          oauth_state: {
+            guid: 'test_connection_id',
+            inbound_member_guid: 'test_connection_id',
+            outbound_member_guid: 'test_connection_id',
+            auth_status: OAuthStatus.ERROR,
+            error_reason: ConnectionStatus.DENIED
+          }
         }
-      })
+      )
     })
   })
 })

--- a/apps/server/src/adapters/index.ts
+++ b/apps/server/src/adapters/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import config from '../config'
 import * as logger from '../infra/logger'
 import providerCredentials from '../providerCredentials'
 import { AnalyticsClient } from '../services/analyticsClient'
@@ -22,21 +21,22 @@ import { FinicityAdapter } from './finicity'
 import { MxAdapter } from './mx'
 import { SophtronAdapter } from './sophtron'
 
-function getProviderAdapter(provider: string, config: any): WidgetAdapter {
+export function getProviderAdapter(provider: string): WidgetAdapter {
   switch (provider) {
     case 'mx':
-      return new MxAdapter(config, false)
+      return new MxAdapter(false)
     case 'mx_int':
-      return new MxAdapter(config, true)
+      return new MxAdapter(true)
     case 'sophtron':
-      return new SophtronAdapter(config)
+      return new SophtronAdapter()
     case 'akoya':
-      return new AkoyaAdapter(config, false)
+      return new AkoyaAdapter(false)
     case 'akoya_sandbox':
-      return new AkoyaAdapter(config, true)
+      return new AkoyaAdapter(true)
     case 'finicity':
+      return new FinicityAdapter()
     case 'finicity_sandbox':
-      return new FinicityAdapter(config)
+      return new FinicityAdapter(true)
     default:
       // throw new Error(`Unsupported provider ${provider}`);
       return null
@@ -81,9 +81,8 @@ export class ProviderAdapterBase {
 
     this.analyticsClient = new AnalyticsClient(token)
     try {
-      const conf = providerCredentials
-      this.providerAdapter = getProviderAdapter(this.context?.provider, conf)
-      this.providers = Object.values(conf)
+      this.providerAdapter = getProviderAdapter(this.context?.provider)
+      this.providers = Object.values(providerCredentials)
         .filter((v: any) => v.available)
         .map((v: any) => v.provider)
       return true

--- a/apps/server/src/adapters/mx.test.ts
+++ b/apps/server/src/adapters/mx.test.ts
@@ -31,25 +31,9 @@ import { createUserData, listUsersData } from '../test/testData/users'
 import { server } from '../test/testServer'
 import { EXTENDED_HISTORY_NOT_SUPPORTED_MSG, MxAdapter } from './mx'
 
-const mxAdapterInt = new MxAdapter(
-  {
-    mxInt: {
-      username: 'testUsername',
-      password: 'testPassword'
-    }
-  },
-  true
-)
+const mxAdapterInt = new MxAdapter(true)
 
-const mxAdapter = new MxAdapter(
-  {
-    mxProd: {
-      username: 'testUsername',
-      password: 'testPassword'
-    }
-  },
-  false
-)
+const mxAdapter = new MxAdapter(false)
 
 const institutionResponse = institutionData.institution
 
@@ -176,7 +160,10 @@ describe('mx provider', () => {
 
       it('retreieves and transforms member credentials', async () => {
         expect(
-          await mxAdapter.ListConnectionCredentials('testMemberId', 'testUserId')
+          await mxAdapter.ListConnectionCredentials(
+            'testMemberId',
+            'testUserId'
+          )
         ).toEqual([
           {
             id: firstCredential.guid,
@@ -595,7 +582,10 @@ describe('mx provider', () => {
     describe('GetConnectionById', () => {
       it('returns the member from readMember', async () => {
         const testUserId = 'userId'
-        const member = await mxAdapter.GetConnectionById('connectionId', testUserId)
+        const member = await mxAdapter.GetConnectionById(
+          'connectionId',
+          testUserId
+        )
 
         const testMember = connectionByIdMemberData.member
 

--- a/apps/server/src/adapters/mx.ts
+++ b/apps/server/src/adapters/mx.ts
@@ -3,9 +3,10 @@ import * as logger from '../infra/logger'
 import type {
   CredentialRequest,
   CredentialsResponseBody,
-  MemberResponse
+  MemberResponse,
+  MxPlatformApiFactory
 } from '../providerApiClients/mx'
-import { Configuration, MxPlatformApiFactory } from '../providerApiClients/mx'
+import { MxIntApiClient, MxProdApiClient } from '../providerApiClients/mx'
 import { get, set } from '../services/storageClient/redis'
 import type {
   Challenge,
@@ -55,24 +56,12 @@ function fromMxMember(member: MemberResponse, provider: string): Connection {
 
 export class MxAdapter implements WidgetAdapter {
   apiClient: ReturnType<typeof MxPlatformApiFactory>
-  mxConfig: any
   provider: string
 
-  constructor(config: any, int: boolean) {
-    const { mxInt, mxProd } = config
+  constructor(int: boolean) {
     this.provider = int ? 'mx_int' : 'mx'
-    this.mxConfig = int ? mxInt : mxProd
 
-    this.apiClient = MxPlatformApiFactory(
-      new Configuration({
-        ...this.mxConfig,
-        baseOptions: {
-          headers: {
-            Accept: 'application/vnd.mx.api.v1+json'
-          }
-        }
-      })
-    )
+    this.apiClient = int ? MxIntApiClient : MxProdApiClient
   }
 
   async GetInstitutionById(id: string): Promise<Institution> {

--- a/apps/server/src/adapters/sophtron.test.ts
+++ b/apps/server/src/adapters/sophtron.test.ts
@@ -1,5 +1,4 @@
 import { server } from '../test/testServer'
-import config from '../config'
 import { SophtronAdapter } from './sophtron'
 import { HttpResponse, http } from 'msw'
 import {
@@ -33,13 +32,7 @@ import {
   customerFromUniqueIdData
 } from '../test/testData/sophtronCustomer'
 
-const adapter = new SophtronAdapter({
-  sophtron: {
-    clientId: 'testClientId',
-    endpoint: config.SophtronApiServiceEndpoint,
-    secret: 'testSecret'
-  }
-})
+const adapter = new SophtronAdapter()
 
 const testId = 'testId'
 const testUserId = 'testUserId'

--- a/apps/server/src/adapters/sophtron.ts
+++ b/apps/server/src/adapters/sophtron.ts
@@ -1,3 +1,4 @@
+import providerCredentials from '../providerCredentials'
 import type {
   Challenge,
   Connection,
@@ -31,10 +32,9 @@ export class SophtronAdapter implements WidgetAdapter {
   apiClient: any
   apiClientV1: any
 
-  constructor(config: any) {
-    const { sophtron } = config
-    this.apiClient = new SophtronClient(sophtron)
-    this.apiClientV1 = new SophtronClientV1(sophtron)
+  constructor() {
+    this.apiClient = new SophtronClient(providerCredentials.sophtron)
+    this.apiClientV1 = new SophtronClientV1(providerCredentials.sophtron)
   }
 
   async GetInstitutionById(id: string): Promise<Institution> {

--- a/apps/server/src/connect/connectApi.test.ts
+++ b/apps/server/src/connect/connectApi.test.ts
@@ -1,5 +1,5 @@
-import { institutionData } from '../test/testData/institution'
 import { MxAdapter } from '../adapters/mx'
+import { institutionData } from '../test/testData/institution'
 import { ConnectApi } from './connectApi'
 
 const connectApi = new ConnectApi({
@@ -11,15 +11,8 @@ const connectApi = new ConnectApi({
   }
 })
 
-const mxApiClient = new MxAdapter(
-  {
-    mxProd: {
-      username: 'testUsername',
-      password: 'testPassword'
-    }
-  },
-  false
-)
+const isIntEnv = false
+const mxApiClient = new MxAdapter(isIntEnv)
 
 connectApi.providerAdapter = mxApiClient
 

--- a/apps/server/src/connect/connectApiExpress.js
+++ b/apps/server/src/connect/connectApiExpress.js
@@ -7,7 +7,6 @@ import { info } from '../infra/logger'
 import { ApiEndpoints } from '../shared/connect/ApiEndpoint'
 import { ConnectionStatus } from '../shared/contract.ts'
 import { ConnectApi } from './connectApi'
-import stubs from './instrumentations.js'
 import {
   accountsDataHandler,
   identityDataHandler,
@@ -19,6 +18,7 @@ import {
   getInstitutionHandler,
   getInstitutionsHandler
 } from './institutionEndpoints'
+import stubs from './instrumentations.js'
 
 const AGGREGATION_JOB_TYPE = 0
 

--- a/apps/server/src/connect/dataEndpoints.test.ts
+++ b/apps/server/src/connect/dataEndpoints.test.ts
@@ -1,24 +1,26 @@
-import { Request, Response } from 'express'
-import {
-  AccountsDataQueryParameters,
-  IdentityDataQueryParameters,
-  TransactionsDataQueryParameters,
-  accountsDataHandler,
-  identityDataHandler,
-  transactionsDataHandler
-} from './dataEndpoints'
-import {
-  mxVcAccountsData,
-  mxVcIdentityData,
-  mxVcTranscationsData
-} from '../test/testData/mxVcData'
-import { server } from '../test/testServer'
+import type { Response } from 'express'
 import { HttpResponse, http } from 'msw'
 import {
   MX_VC_GET_ACCOUNTS_PATH,
   MX_VC_GET_IDENTITY_PATH,
   MX_VC_GET_TRANSACTIONS_PATH
 } from '../test/handlers'
+import {
+  mxVcAccountsData,
+  mxVcIdentityData,
+  mxVcTranscationsData
+} from '../test/testData/mxVcData'
+import { server } from '../test/testServer'
+import type {
+  AccountsRequest,
+  IdentityRequest,
+  TransactionsRequest
+} from './dataEndpoints'
+import {
+  accountsDataHandler,
+  identityDataHandler,
+  transactionsDataHandler
+} from './dataEndpoints'
 
 describe('dataEndpoints', () => {
   describe('accountsDataHandler', () => {
@@ -27,13 +29,13 @@ describe('dataEndpoints', () => {
         send: jest.fn()
       } as unknown as Response
 
-      const req = {
+      const req: AccountsRequest = {
         query: {
-          connectionId: 'testConnectionId',
+          connection_id: 'testConnectionId',
           provider: 'mx',
-          userId: 'testUserId'
-        } as AccountsDataQueryParameters
-      } as unknown as Request
+          user_id: 'testUserId'
+        }
+      }
 
       await accountsDataHandler(req, res)
 
@@ -55,17 +57,18 @@ describe('dataEndpoints', () => {
         status: jest.fn()
       } as unknown as Response
 
-      const req = {
+      const req: AccountsRequest = {
         query: {
-          connectionId: 'testConnectionId',
+          connection_id: 'testConnectionId',
           provider: 'mx',
-          userId: 'testUserId'
-        } as AccountsDataQueryParameters
-      } as unknown as Request
+          user_id: 'testUserId'
+        }
+      }
 
       await accountsDataHandler(req, res)
 
       expect(res.send).toHaveBeenCalledWith('Something went wrong')
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(res.status).toHaveBeenCalledWith(400)
     })
   })
@@ -77,13 +80,13 @@ describe('dataEndpoints', () => {
         status: jest.fn()
       } as unknown as Response
 
-      const req = {
+      const req: IdentityRequest = {
         query: {
-          connectionId: 'testConnectionId',
+          connection_id: 'testConnectionId',
           provider: 'mx',
-          userId: 'testUserId'
-        } as IdentityDataQueryParameters
-      } as unknown as Request
+          user_id: 'testUserId'
+        }
+      }
 
       await identityDataHandler(req, res)
 
@@ -105,17 +108,18 @@ describe('dataEndpoints', () => {
         status: jest.fn()
       } as unknown as Response
 
-      const req = {
+      const req: IdentityRequest = {
         query: {
-          connectionId: 'testConnectionId',
+          connection_id: 'testConnectionId',
           provider: 'mx',
-          userId: 'testUserId'
-        } as IdentityDataQueryParameters
-      } as unknown as Request
+          user_id: 'testUserId'
+        }
+      }
 
       await identityDataHandler(req, res)
 
       expect(res.send).toHaveBeenCalledWith('Something went wrong')
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(res.status).toHaveBeenCalledWith(400)
     })
   })
@@ -127,13 +131,15 @@ describe('dataEndpoints', () => {
         status: jest.fn()
       } as unknown as Response
 
-      const req = {
+      const req: TransactionsRequest = {
         query: {
-          accountId: 'testAccountId',
+          account_id: 'testAccountId',
           provider: 'mx',
-          userId: 'testUserId'
-        } as TransactionsDataQueryParameters
-      } as unknown as Request
+          user_id: 'testUserId',
+          start_time: undefined,
+          end_time: undefined
+        }
+      }
 
       await transactionsDataHandler(req, res)
 
@@ -155,17 +161,20 @@ describe('dataEndpoints', () => {
         status: jest.fn()
       } as unknown as Response
 
-      const req = {
+      const req: TransactionsRequest = {
         query: {
-          accountId: 'testAccountId',
+          account_id: 'testAccountId',
           provider: 'mx',
-          userId: 'testUserId'
-        } as TransactionsDataQueryParameters
-      } as unknown as Request
+          user_id: 'testUserId',
+          start_time: undefined,
+          end_time: undefined
+        }
+      }
 
       await transactionsDataHandler(req, res)
 
       expect(res.send).toHaveBeenCalledWith('Something went wrong')
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(res.status).toHaveBeenCalledWith(400)
     })
   })

--- a/apps/server/src/connect/dataEndpoints.ts
+++ b/apps/server/src/connect/dataEndpoints.ts
@@ -1,18 +1,23 @@
-import { Request, Response } from 'express'
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { Request, Response } from 'express'
+import { getProviderAdapter } from '../adapters'
 import getVC from '../services/vcProviders'
 
 export interface AccountsDataQueryParameters {
-  connectionId: string
+  connection_id: string
   provider: string
-  userId: string
+  user_id: string
 }
 
 export const accountsDataHandler = async (req: Request, res: Response) => {
-  const { provider, connectionId, userId } =
+  const { provider, connection_id, user_id } =
     req.query as unknown as AccountsDataQueryParameters
 
+  const providerAdapter = getProviderAdapter(provider)
+  const providerUserId = await providerAdapter.ResolveUserId(user_id)
+
   try {
-    const vc = await getVC(provider, connectionId, 'accounts', userId)
+    const vc = await getVC(provider, connection_id, 'accounts', providerUserId)
     res.send({
       jwt: vc
     })
@@ -23,17 +28,20 @@ export const accountsDataHandler = async (req: Request, res: Response) => {
 }
 
 export interface IdentityDataQueryParameters {
-  connectionId: string
+  connection_id: string
   provider: string
-  userId: string
+  user_id: string
 }
 
 export const identityDataHandler = async (req: Request, res: Response) => {
-  const { provider, connectionId, userId } =
+  const { provider, connection_id, user_id } =
     req.query as unknown as IdentityDataQueryParameters
 
+  const providerAdapter = getProviderAdapter(provider)
+  const providerUserId = await providerAdapter.ResolveUserId(user_id)
+
   try {
-    const vc = await getVC(provider, connectionId, 'identity', userId)
+    const vc = await getVC(provider, connection_id, 'identity', providerUserId)
     res.send({
       jwt: vc
     })
@@ -44,24 +52,27 @@ export const identityDataHandler = async (req: Request, res: Response) => {
 }
 
 export interface TransactionsDataQueryParameters {
-  accountId: string
+  account_id: string
   endTime: string
   provider: string
   startTime: string
-  userId: string
+  user_id: string
 }
 
 export const transactionsDataHandler = async (req: Request, res: Response) => {
-  const { provider, userId, accountId, startTime, endTime } =
+  const { provider, user_id, account_id, startTime, endTime } =
     req.query as unknown as TransactionsDataQueryParameters
+
+  const providerAdapter = getProviderAdapter(provider)
+  const providerUserId = await providerAdapter.ResolveUserId(user_id)
 
   try {
     const vc = await getVC(
       provider,
       undefined,
       'transactions',
-      userId,
-      accountId,
+      providerUserId,
+      account_id,
       startTime,
       endTime
     )

--- a/apps/server/src/connect/dataEndpoints.ts
+++ b/apps/server/src/connect/dataEndpoints.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { Request, Response } from 'express'
+import type { Response } from 'express'
 import { getProviderAdapter } from '../adapters'
 import getVC from '../services/vcProviders'
 
@@ -9,9 +9,23 @@ export interface AccountsDataQueryParameters {
   user_id: string
 }
 
-export const accountsDataHandler = async (req: Request, res: Response) => {
-  const { provider, connection_id, user_id } =
-    req.query as unknown as AccountsDataQueryParameters
+export interface AccountsRequest {
+  query: AccountsDataQueryParameters
+}
+
+export interface IdentityRequest {
+  query: IdentityDataQueryParameters
+}
+
+export interface TransactionsRequest {
+  query: TransactionsDataQueryParameters
+}
+
+export const accountsDataHandler = async (
+  req: AccountsRequest,
+  res: Response
+) => {
+  const { provider, connection_id, user_id } = req.query
 
   const providerAdapter = getProviderAdapter(provider)
   const providerUserId = await providerAdapter.ResolveUserId(user_id)
@@ -33,7 +47,10 @@ export interface IdentityDataQueryParameters {
   user_id: string
 }
 
-export const identityDataHandler = async (req: Request, res: Response) => {
+export const identityDataHandler = async (
+  req: IdentityRequest,
+  res: Response
+) => {
   const { provider, connection_id, user_id } =
     req.query as unknown as IdentityDataQueryParameters
 
@@ -53,14 +70,17 @@ export const identityDataHandler = async (req: Request, res: Response) => {
 
 export interface TransactionsDataQueryParameters {
   account_id: string
-  endTime: string
+  end_time: string
   provider: string
-  startTime: string
+  start_time: string
   user_id: string
 }
 
-export const transactionsDataHandler = async (req: Request, res: Response) => {
-  const { provider, user_id, account_id, startTime, endTime } =
+export const transactionsDataHandler = async (
+  req: TransactionsRequest,
+  res: Response
+) => {
+  const { provider, user_id, account_id, start_time, end_time } =
     req.query as unknown as TransactionsDataQueryParameters
 
   const providerAdapter = getProviderAdapter(provider)
@@ -73,8 +93,8 @@ export const transactionsDataHandler = async (req: Request, res: Response) => {
       'transactions',
       providerUserId,
       account_id,
-      startTime,
-      endTime
+      start_time,
+      end_time
     )
     res.send({
       jwt: vc

--- a/apps/server/src/providerApiClients/mx.ts
+++ b/apps/server/src/providerApiClients/mx.ts
@@ -1,4 +1,28 @@
+import providerCredentials from '../providerCredentials'
+import { Configuration, MxPlatformApiFactory } from './mxClient'
 export * from './mxClient/api'
 export * from './mxClient/configuration'
 
 export const BASE_PATH = 'https://api.mx.com'.replace(/\/+$/, '')
+
+export const MxProdApiClient = MxPlatformApiFactory(
+  new Configuration({
+    ...providerCredentials.mxProd,
+    baseOptions: {
+      headers: {
+        Accept: 'application/vnd.mx.api.v2beta+json'
+      }
+    }
+  })
+)
+
+export const MxIntApiClient = MxPlatformApiFactory(
+  new Configuration({
+    ...providerCredentials.mxInt,
+    baseOptions: {
+      headers: {
+        Accept: 'application/vnd.mx.api.v2beta+json'
+      }
+    }
+  })
+)

--- a/apps/server/src/services/vcProviders/mxVc.ts
+++ b/apps/server/src/services/vcProviders/mxVc.ts
@@ -1,8 +1,5 @@
 import { info } from '../../infra/logger'
 import { getVc as getMxVc } from '../../providerApiClients/mxClient/vc'
-import providerCredentials from '../../providerCredentials'
-
-const { mxInt, mxProd } = providerCredentials
 
 export default async function getVC(
   isProd: boolean,

--- a/apps/server/src/services/vcProviders/sophtronVc.ts
+++ b/apps/server/src/services/vcProviders/sophtronVc.ts
@@ -18,7 +18,7 @@ export default async function getVC(
       path = `customers/${userId}/members/${connectionId}/accounts`
       break
     case 'transactions':
-      path = `customers/${userId}/accounts/${accountId}/transactions?startTime=${startTime}&endTime=${endTime}`
+      path = `customers/${userId}/accounts/${accountId}/transactions?start_time=${startTime}&end_time=${endTime}`
       break
     default:
       break

--- a/apps/server/src/services/vcProviders/sophtronVc.ts
+++ b/apps/server/src/services/vcProviders/sophtronVc.ts
@@ -18,7 +18,7 @@ export default async function getVC(
       path = `customers/${userId}/members/${connectionId}/accounts`
       break
     case 'transactions':
-      path = `customers/${userId}/accounts/${accountId}/transactions?start_time=${startTime}&end_time=${endTime}`
+      path = `customers/${userId}/accounts/${accountId}/transactions?startTime=${startTime}&endTime=${endTime}`
       break
     default:
       break

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Server",
+  "baseUrl": "src",
   "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "allowJs": true,
@@ -16,5 +17,10 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*", "playwright/**/*", "jest.config.js"],
-  "exclude": ["dist", "node_modules", "cypress.config.ts", "cypress.config.alternate.ts"]
+  "exclude": [
+    "dist",
+    "node_modules",
+    "cypress.config.ts",
+    "cypress.config.alternate.ts"
+  ]
 }

--- a/openApiDocumentation.json
+++ b/openApiDocumentation.json
@@ -82,7 +82,7 @@
         "parameters": [
           {
             "description": "The connection id",
-            "name": "connectionId",
+            "name": "connection_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -100,7 +100,7 @@
           },
           {
             "description": "The user id for the connection",
-            "name": "userId",
+            "name": "user_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -120,7 +120,7 @@
         "parameters": [
           {
             "description": "The connection id",
-            "name": "connectionId",
+            "name": "connection_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -138,7 +138,7 @@
           },
           {
             "description": "The user id for the connection",
-            "name": "userId",
+            "name": "user_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -158,7 +158,7 @@
         "parameters": [
           {
             "description": "The account id",
-            "name": "accountId",
+            "name": "account_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -167,7 +167,7 @@
           },
           {
             "description": "Period end of the transactions to return. This is only used for Sophtron, and it is required for Sophtron. ex: 1/1/2024",
-            "name": "endTime",
+            "name": "end_time",
             "in": "query",
             "schema": {
               "type": "string"
@@ -184,7 +184,7 @@
           },
           {
             "description": "Period start of the transactions to return. This is only used for Sophtron, and it is required for Sophtron. ex: 1/1/2024",
-            "name": "startTime",
+            "name": "start_time",
             "in": "query",
             "schema": {
               "type": "string"
@@ -192,7 +192,7 @@
           },
           {
             "description": "The user id for the connection",
-            "name": "userId",
+            "name": "user_id",
             "in": "query",
             "required": true,
             "schema": {


### PR DESCRIPTION
Instead of expecting the user_guid to be passed into the data endpoint we're expecting the user_id which is defined in the widget url, the data endpoints will resolve the id to the provider and request the data from the provider.