### PR TITLE
add raw_status that's used by current clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- added raw_status in connection object which will later made available through client side events, the raw_status field contains the status returned from aggregator before mapped to universal widget contract, this richer information enables client to track the connection status at a more detailed and accurate level which in turns provide the opportunity to trigger more process at a better timing, as well as make diagnosing easier
+- Now passing custom events to the connect widget for member status update and member connected events. Added some sophtron specific values for member status update.
 
 ## [1.0.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.10]
+
+### Changed
+
+- added raw_status in connection object which will later made available through client side events, the raw_status field contains the status returned from aggregator before mapped to universal widget contract, this richer information enables client to track the connection status at a more detailed and accurate level which in turns provide the opportunity to trigger more process at a better timing, as well as make diagnosing easier
+
 ## [1.0.9]
 
 ### Fixed

--- a/apps/server/jest.config.js
+++ b/apps/server/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   setupFilesAfterEnv: ["./jestSetup.ts"],
   testPathIgnorePatterns: [
     "<rootDir>/node_modules/",
+    "<rootDir>/dist/",
     "<rootDir>/src/utils/Test.js",
     "<rootDir>/src/config/",
   ],

--- a/apps/server/openApiInternal.json
+++ b/apps/server/openApiInternal.json
@@ -494,6 +494,19 @@
                     "is_oauth": false,
                     "aggregator": "testExampleC",
                     "is_being_aggregated": false,
+                    "postMessageEventData": {
+                      "memberConnected": {
+                        "aggregator": "mx_int",
+                        "member_guid": "MBR-b3b1c287-9dea-447a-83c9-2554d7cfc310",
+                        "user_guid": "USR-35223fe6-391d-4d02-9184-55a8fcb0b099"
+                      },
+                      "memberStatusUpdate": {
+                        "aggregator": "mx_int",
+                        "member_guid": "MBR-b3b1c287-9dea-447a-83c9-2554d7cfc310",
+                        "user_guid": "USR-35223fe6-391d-4d02-9184-55a8fcb0b099",
+                        "connection_status": 0
+                      }
+                    },
                     "user_guid": "e07115cc-bbf9-466a-b7db-cdbc9c7cd31b",
                     "mfa": {
                       "credentials": [

--- a/apps/server/src/connect/connectApi.test.ts
+++ b/apps/server/src/connect/connectApi.test.ts
@@ -73,7 +73,6 @@ describe("connectApi", () => {
         mfa: {
           credentials: [],
         },
-        raw_status: 'raw_status',
         selected_account_id: undefined,
         most_recent_job_guid: testJobId,
         oauth_window_uri: undefined,

--- a/apps/server/src/connect/connectApi.test.ts
+++ b/apps/server/src/connect/connectApi.test.ts
@@ -53,6 +53,19 @@ describe("connectApi", () => {
           },
           most_recent_job_guid: null,
           oauth_window_uri: undefined,
+          postMessageEventData: {
+            memberConnected: {
+              aggregator: "testExampleA",
+              member_guid: "testConnectionId",
+              user_guid: undefined,
+            },
+            memberStatusUpdate: {
+              aggregator: "testExampleA",
+              connection_status: 0,
+              member_guid: "testConnectionId",
+              user_guid: undefined,
+            },
+          },
           user_guid: undefined,
         },
       });
@@ -73,9 +86,23 @@ describe("connectApi", () => {
         mfa: {
           credentials: [],
         },
-        selected_account_id: undefined,
         most_recent_job_guid: testJobId,
         oauth_window_uri: undefined,
+        postMessageEventData: {
+          memberConnected: {
+            aggregator: "testExampleA",
+            member_guid: "testConnectionId",
+            test: "connected",
+            user_guid: null,
+          },
+          memberStatusUpdate: {
+            aggregator: "testExampleA",
+            connection_status: 6,
+            member_guid: "testConnectionId",
+            test: "updated",
+            user_guid: null,
+          },
+        },
         user_guid: null,
       });
     });

--- a/apps/server/src/connect/connectApi.test.ts
+++ b/apps/server/src/connect/connectApi.test.ts
@@ -73,6 +73,8 @@ describe("connectApi", () => {
         mfa: {
           credentials: [],
         },
+        raw_status: 'raw_status',
+        selected_account_id: undefined,
         most_recent_job_guid: testJobId,
         oauth_window_uri: undefined,
         user_guid: null,

--- a/apps/server/src/connect/connectApi.ts
+++ b/apps/server/src/connect/connectApi.ts
@@ -10,6 +10,7 @@ function mapConnection(connection: Connection): Member {
     institution_guid: connection.institution_code,
     guid: connection.id,
     connection_status: connection.status ?? ConnectionStatus.CREATED, // ?
+    raw_status: connection.raw_status,
     most_recent_job_guid:
       connection.status === ConnectionStatus.CONNECTED
         ? connection.cur_job_id
@@ -17,6 +18,7 @@ function mapConnection(connection: Connection): Member {
     is_oauth: connection.is_oauth,
     oauth_window_uri: connection.oauth_window_uri,
     aggregator: connection.aggregator,
+    selected_account_id: connection.selected_account_id,
     is_being_aggregated: connection.is_being_aggregated,
     user_guid: connection.userId,
     mfa: {

--- a/apps/server/src/connect/connectApi.ts
+++ b/apps/server/src/connect/connectApi.ts
@@ -6,11 +6,20 @@ import { AggregatorAdapterBase } from "../adapters";
 import type { Member, MemberResponse } from "../shared/connect/contract";
 
 function mapConnection(connection: Connection): Member {
+  const userId = connection.userId;
+  const memberGuid = connection.id;
+  const connectionStatus = connection.status ?? ConnectionStatus.CREATED;
+
+  const sharedEventData = {
+    aggregator: connection.aggregator,
+    member_guid: memberGuid,
+    user_guid: userId,
+  };
+
   return {
     institution_guid: connection.institution_code,
-    guid: connection.id,
-    connection_status: connection.status ?? ConnectionStatus.CREATED, // ?
-    raw_status: connection.raw_status,
+    guid: memberGuid,
+    connection_status: connectionStatus,
     most_recent_job_guid:
       connection.status === ConnectionStatus.CONNECTED
         ? connection.cur_job_id
@@ -18,9 +27,19 @@ function mapConnection(connection: Connection): Member {
     is_oauth: connection.is_oauth,
     oauth_window_uri: connection.oauth_window_uri,
     aggregator: connection.aggregator,
-    selected_account_id: connection.selected_account_id,
+    postMessageEventData: {
+      memberConnected: {
+        ...(connection.postMessageEventData?.memberConnected || {}),
+        ...sharedEventData,
+      },
+      memberStatusUpdate: {
+        ...(connection.postMessageEventData?.memberStatusUpdate || {}),
+        ...sharedEventData,
+        connection_status: connectionStatus,
+      },
+    },
     is_being_aggregated: connection.is_being_aggregated,
-    user_guid: connection.userId,
+    user_guid: userId,
     mfa: {
       credentials: connection.challenges?.map((c) => {
         const ret = {

--- a/apps/server/src/connect/oauthEndpoints.test.ts
+++ b/apps/server/src/connect/oauthEndpoints.test.ts
@@ -130,8 +130,6 @@ describe("webhookHandler", () => {
 
     expect(res.send).toHaveBeenCalledWith({
       status: ConnectionStatus.CONNECTED,
-      id: undefined,
-      userId: undefined,
     });
   });
 

--- a/apps/server/src/connect/oauthEndpoints.test.ts
+++ b/apps/server/src/connect/oauthEndpoints.test.ts
@@ -131,8 +131,7 @@ describe("webhookHandler", () => {
     expect(res.send).toHaveBeenCalledWith({
       status: ConnectionStatus.CONNECTED,
       id: undefined,
-      raw_status: 'raw_status',
-      userId: undefined
+      userId: undefined,
     });
   });
 

--- a/apps/server/src/connect/oauthEndpoints.test.ts
+++ b/apps/server/src/connect/oauthEndpoints.test.ts
@@ -130,6 +130,9 @@ describe("webhookHandler", () => {
 
     expect(res.send).toHaveBeenCalledWith({
       status: ConnectionStatus.CONNECTED,
+      id: undefined,
+      raw_status: 'raw_status',
+      userId: undefined
     });
   });
 

--- a/apps/server/src/shared/connect/contract.ts
+++ b/apps/server/src/shared/connect/contract.ts
@@ -65,6 +65,8 @@ export interface Member {
   aggregated_at?: string | null;
   background_aggregation_is_disabled?: boolean;
   connection_status?: string | null | number; //
+  raw_status?: string | null //the original aggregator status
+  selected_account_id?: string | null; // the account_id that's selected during single_account_select
   guid: string;
   id?: string | null;
   institution_code?: string | null;

--- a/apps/server/src/shared/connect/contract.ts
+++ b/apps/server/src/shared/connect/contract.ts
@@ -1,3 +1,5 @@
+import type { PostMessageEventData } from "@repo/utils";
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface Credential {
   guid: string; //
@@ -65,8 +67,7 @@ export interface Member {
   aggregated_at?: string | null;
   background_aggregation_is_disabled?: boolean;
   connection_status?: string | null | number; //
-  raw_status?: string | null //the original aggregator status
-  selected_account_id?: string | null; // the account_id that's selected during single_account_select
+  postMessageEventData?: PostMessageEventData;
   guid: string;
   id?: string | null;
   institution_code?: string | null;
@@ -88,6 +89,7 @@ export interface Member {
   skip_aggregation?: boolean | null;
   credentials?: Credential[];
 }
+
 export interface MemberResponse {
   member: Member;
 }

--- a/apps/server/src/test-adapter/adapter.test.ts
+++ b/apps/server/src/test-adapter/adapter.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComboJobTypes, ConnectionStatus } from "@repo/utils";
-import { TestAdapter, testConnectionId, testInstitutionCode } from "./adapter";
+import {
+  postMessageEventData,
+  TestAdapter,
+  testConnectionId,
+  testInstitutionCode,
+} from "./adapter";
 import {
   testDataRequestValidators,
   testDataRequestValidatorStartTimeError,
@@ -26,6 +31,7 @@ const successConnectionStatus = {
   id: testConnectionId,
   cur_job_id: "testJobId",
   userId: "userId",
+  postMessageEventData,
   status: ConnectionStatus.CONNECTED,
   challenges: [],
 } as any;

--- a/apps/server/src/test-adapter/adapter.test.ts
+++ b/apps/server/src/test-adapter/adapter.test.ts
@@ -26,7 +26,6 @@ const successConnectionStatus = {
   id: testConnectionId,
   cur_job_id: "testJobId",
   userId: "userId",
-  raw_status: 'raw_status',
   status: ConnectionStatus.CONNECTED,
   challenges: [],
 } as any;
@@ -204,7 +203,6 @@ describe("TestAdapter", () => {
         id: testConnectionId,
         cur_job_id: "testJobId",
         userId: "testUserId",
-        raw_status: 'raw_status',
         status: ConnectionStatus.CHALLENGED,
         challenges: [
           {
@@ -326,23 +324,21 @@ describe("TestAdapter", () => {
 
       expect(ret).toEqual({
         id: "aggregator-userId",
-        raw_status: 'raw_status',
         status: ConnectionStatus.CONNECTED,
-        userId: undefined
+        userId: undefined,
       });
     });
 
     it("returns with denied if the code is error", async () => {
       const ret = await testAdapterA.HandleOauthResponse({
         query: {
-          code: "error"
+          code: "error",
         },
       });
       expect(ret).toEqual({
         status: ConnectionStatus.DENIED,
         error: "error",
-        raw_status: "raw_status",
+      });
     });
   });
-});
 });

--- a/apps/server/src/test-adapter/adapter.test.ts
+++ b/apps/server/src/test-adapter/adapter.test.ts
@@ -26,6 +26,7 @@ const successConnectionStatus = {
   id: testConnectionId,
   cur_job_id: "testJobId",
   userId: "userId",
+  raw_status: 'raw_status',
   status: ConnectionStatus.CONNECTED,
   challenges: [],
 } as any;
@@ -203,6 +204,7 @@ describe("TestAdapter", () => {
         id: testConnectionId,
         cur_job_id: "testJobId",
         userId: "testUserId",
+        raw_status: 'raw_status',
         status: ConnectionStatus.CHALLENGED,
         challenges: [
           {
@@ -319,23 +321,28 @@ describe("TestAdapter", () => {
   describe("HandleOauthResponse", () => {
     it("responds with success if the code isn't error", async () => {
       const ret = await testAdapterA.HandleOauthResponse({
-        query: {},
+        query: { state: `${aggregator}-userId` },
       });
 
       expect(ret).toEqual({
+        id: "aggregator-userId",
+        raw_status: 'raw_status',
         status: ConnectionStatus.CONNECTED,
+        userId: undefined
       });
     });
 
     it("returns with denied if the code is error", async () => {
       const ret = await testAdapterA.HandleOauthResponse({
         query: {
-          code: "error",
+          code: "error"
         },
       });
       expect(ret).toEqual({
         status: ConnectionStatus.DENIED,
-      });
+        error: "error",
+        raw_status: "raw_status",
     });
   });
+});
 });

--- a/apps/server/src/test-adapter/adapter.test.ts
+++ b/apps/server/src/test-adapter/adapter.test.ts
@@ -325,13 +325,11 @@ describe("TestAdapter", () => {
   describe("HandleOauthResponse", () => {
     it("responds with success if the code isn't error", async () => {
       const ret = await testAdapterA.HandleOauthResponse({
-        query: { state: `${aggregator}-userId` },
+        query: {},
       });
 
       expect(ret).toEqual({
-        id: "aggregator-userId",
         status: ConnectionStatus.CONNECTED,
-        userId: undefined,
       });
     });
 
@@ -343,7 +341,6 @@ describe("TestAdapter", () => {
       });
       expect(ret).toEqual({
         status: ConnectionStatus.DENIED,
-        error: "error",
       });
     });
   });

--- a/apps/server/src/test-adapter/adapter.ts
+++ b/apps/server/src/test-adapter/adapter.ts
@@ -234,7 +234,6 @@ export class TestAdapter implements WidgetAdapter {
         cur_job_id: testJobId,
         userId: "testUserId",
         status: ConnectionStatus.CHALLENGED,
-        raw_status: 'raw_status',
         challenges: [
           {
             id: "CRD-a81b35db-28dd-41ea-aed3-6ec8ef682011",
@@ -261,7 +260,6 @@ export class TestAdapter implements WidgetAdapter {
       cur_job_id: testJobId,
       userId: userId,
       status: ConnectionStatus.CONNECTED,
-      raw_status: 'raw_status',
       challenges: [],
     };
   }
@@ -301,16 +299,14 @@ export class TestAdapter implements WidgetAdapter {
     if (code === "error") {
       return {
         status: ConnectionStatus.DENIED,
-        raw_status: 'raw_status',
         id: request_id,
         error: code,
-      } as Connection
+      } as Connection;
     }
     return {
       status: ConnectionStatus.CONNECTED,
-      raw_status: 'raw_status',
       userId: code,
-      id: request_id
-    }
+      id: request_id,
+    };
   }
 }

--- a/apps/server/src/test-adapter/adapter.ts
+++ b/apps/server/src/test-adapter/adapter.ts
@@ -19,6 +19,15 @@ export const testJobId = "testJobId";
 export const testInstitutionCode = "institutionCode";
 export const testConnectionId = "testConnectionId";
 
+export const postMessageEventData = {
+  memberConnected: {
+    test: "connected",
+  },
+  memberStatusUpdate: {
+    test: "updated",
+  },
+};
+
 const createRedisStatusKey = ({
   aggregator,
   userId,
@@ -259,6 +268,7 @@ export class TestAdapter implements WidgetAdapter {
       id: testConnectionId,
       cur_job_id: testJobId,
       userId: userId,
+      postMessageEventData,
       status: ConnectionStatus.CONNECTED,
       challenges: [],
     };

--- a/apps/server/src/test-adapter/adapter.ts
+++ b/apps/server/src/test-adapter/adapter.ts
@@ -234,6 +234,7 @@ export class TestAdapter implements WidgetAdapter {
         cur_job_id: testJobId,
         userId: "testUserId",
         status: ConnectionStatus.CHALLENGED,
+        raw_status: 'raw_status',
         challenges: [
           {
             id: "CRD-a81b35db-28dd-41ea-aed3-6ec8ef682011",
@@ -260,6 +261,7 @@ export class TestAdapter implements WidgetAdapter {
       cur_job_id: testJobId,
       userId: userId,
       status: ConnectionStatus.CONNECTED,
+      raw_status: 'raw_status',
       challenges: [],
     };
   }
@@ -295,16 +297,20 @@ export class TestAdapter implements WidgetAdapter {
   }: {
     query: Record<string, string>;
   }): Promise<Connection> {
-    const { code } = query;
-
+    const { state: request_id, code } = query;
     if (code === "error") {
       return {
         status: ConnectionStatus.DENIED,
-      } as Connection;
+        raw_status: 'raw_status',
+        id: request_id,
+        error: code,
+      } as Connection
     }
-
     return {
       status: ConnectionStatus.CONNECTED,
-    } as Connection;
+      raw_status: 'raw_status',
+      userId: code,
+      id: request_id
+    }
   }
 }

--- a/apps/server/src/test-adapter/adapter.ts
+++ b/apps/server/src/test-adapter/adapter.ts
@@ -305,18 +305,15 @@ export class TestAdapter implements WidgetAdapter {
   }: {
     query: Record<string, string>;
   }): Promise<Connection> {
-    const { state: request_id, code } = query;
+    const { code } = query;
     if (code === "error") {
       return {
         status: ConnectionStatus.DENIED,
-        id: request_id,
-        error: code,
       } as Connection;
     }
+
     return {
       status: ConnectionStatus.CONNECTED,
-      userId: code,
-      id: request_id,
-    };
+    } as Connection;
   }
 }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@mxenabled/connect-widget": "^0.7.0",
+    "@mxenabled/connect-widget": "^0.13.0",
     "@types/node": "^20.11.16",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitejs/plugin-react-swc": "^3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
     "apps/ui": {
       "version": "0.0.15-beta",
       "dependencies": {
-        "@mxenabled/connect-widget": "^0.7.0",
+        "@mxenabled/connect-widget": "^0.13.0",
         "@types/node": "^20.11.16",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitejs/plugin-react-swc": "^3.6.0",
@@ -4663,9 +4663,9 @@
       }
     },
     "node_modules/@mxenabled/connect-widget": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@mxenabled/connect-widget/-/connect-widget-0.7.0.tgz",
-      "integrity": "sha512-6PRkX5MBqwEYU9zVeQasSGGmxNAHALYMf//kiww9xjK+c4EyJsE8ynP9T3odladD8/Quy3+ogO4YdrVrG8R0JQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@mxenabled/connect-widget/-/connect-widget-0.13.0.tgz",
+      "integrity": "sha512-zO0UFh2rwb0NhBcx6MtXZ+LICQ75lf+oF71mGfRxZgpT+szO8DSR6mUOuakQcazVV/GXqgK6fT7R0OnVOu15aA==",
       "dependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
@@ -4688,10 +4688,10 @@
         "@mui/material": "^6.1.5",
         "@reduxjs/toolkit": "^2.2.7",
         "@types/node": "^22.1.0",
-        "axios": "^1.7.4",
+        "axios": "^1.8.4",
         "bowser": "^2.11.0",
         "date-fns": "^3.6.0",
-        "dompurify": "^3.1.6",
+        "dompurify": "^3.2.4",
         "focus-trap-react": "^10.2.3",
         "gettext.js": "^2.0.3",
         "js-sha256": "^0.11.0",
@@ -6289,6 +6289,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
@@ -7260,9 +7261,10 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -8913,9 +8915,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
-      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
+      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ucw-app",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ucw-app",
-      "version": "1.0.7",
+      "version": "1.0.10",
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ucw-app",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "scripts": {
     "build": "turbo build",

--- a/packages/sophtron-adapter/src/adapter.test.ts
+++ b/packages/sophtron-adapter/src/adapter.test.ts
@@ -418,6 +418,9 @@ describe("sophtron adapter", () => {
 
       expect(response).toEqual({
         id: testUserInstitutionId,
+        challenges: null,
+        raw_status: 'success',
+        selected_account_id: '',
         userId: testUserId,
         cur_job_id: testJobId,
         status: ConnectionStatus.CONNECTED,
@@ -447,6 +450,9 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        challenges: null,
+        raw_status: 'failed',
+        selected_account_id: '',
         status: ConnectionStatus.FAILED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -475,6 +481,9 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        challenges: null,
+        raw_status: 'AccountsReady',
+        selected_account_id: '',
         status: ConnectionStatus.CREATED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -488,6 +497,7 @@ describe("sophtron adapter", () => {
             JobType: "verification",
             LastStatus: accountsReadyStatus,
             UserInstitutionID: testUserInstitutionId,
+            AccounntId: 'SAS_ACCOUNT_ID'
           }),
         ),
       );
@@ -519,6 +529,8 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        raw_status: 'AccountsReady',
+        selected_account_id: '',
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -561,6 +573,8 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        raw_status: 'SecurityQuestion',
+        selected_account_id: '',
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -604,6 +618,8 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        raw_status: 'TokenMethod',
+        selected_account_id: '',
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -648,6 +664,8 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        raw_status: 'TokenInput',
+        selected_account_id: '',
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -689,6 +707,8 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        raw_status: 'TokenInput',
+        selected_account_id: '',
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -732,6 +752,8 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        raw_status: 'TokenRead',
+        selected_account_id: '',
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -770,6 +792,8 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
+        raw_status: 'CaptchaImage',
+        selected_account_id: '',
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -798,6 +822,9 @@ describe("sophtron adapter", () => {
       id: testUserInstitutionId,
       userId: testUserId,
       cur_job_id: testJobId,
+      challenges: null,
+      raw_status: undefined,
+      selected_account_id: '',
       status: ConnectionStatus.CREATED,
       aggregator: SOPHTRON_ADAPTER_NAME,
     });

--- a/packages/sophtron-adapter/src/adapter.test.ts
+++ b/packages/sophtron-adapter/src/adapter.test.ts
@@ -382,6 +382,17 @@ describe("sophtron adapter", () => {
   });
 
   describe("GetConnectionStatus", () => {
+    const createPostMessageEventData = ({ rawStatus, selectedAccountId }) => ({
+      memberConnected: {
+        rawStatus,
+        selectedAccountId,
+      },
+      memberStatusUpdate: {
+        rawStatus,
+        selectedAccountId,
+      },
+    });
+
     it("returns the connection using the memberId and userId if there is no jobId", async () => {
       const response = await adapter.GetConnectionStatus(
         testId,
@@ -419,8 +430,10 @@ describe("sophtron adapter", () => {
       expect(response).toEqual({
         id: testUserInstitutionId,
         challenges: null,
-        raw_status: 'success',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "success",
+          selectedAccountId: "",
+        }),
         userId: testUserId,
         cur_job_id: testJobId,
         status: ConnectionStatus.CONNECTED,
@@ -451,8 +464,10 @@ describe("sophtron adapter", () => {
         userId: testUserId,
         cur_job_id: testJobId,
         challenges: null,
-        raw_status: 'failed',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "failed",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.FAILED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -482,8 +497,10 @@ describe("sophtron adapter", () => {
         userId: testUserId,
         cur_job_id: testJobId,
         challenges: null,
-        raw_status: 'AccountsReady',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "AccountsReady",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CREATED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -497,7 +514,7 @@ describe("sophtron adapter", () => {
             JobType: "verification",
             LastStatus: accountsReadyStatus,
             UserInstitutionID: testUserInstitutionId,
-            AccounntId: 'SAS_ACCOUNT_ID'
+            AccounntId: "SAS_ACCOUNT_ID",
           }),
         ),
       );
@@ -529,8 +546,10 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
-        raw_status: 'AccountsReady',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "AccountsReady",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -573,8 +592,10 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
-        raw_status: 'SecurityQuestion',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "SecurityQuestion",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -618,8 +639,10 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
-        raw_status: 'TokenMethod',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "TokenMethod",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -664,8 +687,10 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
-        raw_status: 'TokenInput',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "TokenInput",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -707,8 +732,10 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
-        raw_status: 'TokenInput',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "TokenInput",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -752,8 +779,10 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
-        raw_status: 'TokenRead',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "TokenRead",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
@@ -792,41 +821,45 @@ describe("sophtron adapter", () => {
         id: testUserInstitutionId,
         userId: testUserId,
         cur_job_id: testJobId,
-        raw_status: 'CaptchaImage',
-        selected_account_id: '',
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: "CaptchaImage",
+          selectedAccountId: "",
+        }),
         status: ConnectionStatus.CHALLENGED,
         aggregator: SOPHTRON_ADAPTER_NAME,
       });
     });
-  });
 
-  it("defaults to connection status created", async () => {
-    server.use(
-      http.get(SOPHTRON_GET_JOB_INFO_PATH, () =>
-        HttpResponse.json({
-          JobID: testJobId,
-          JobType: "agg",
-          UserInstitutionID: testUserInstitutionId,
+    it("defaults to connection status created", async () => {
+      server.use(
+        http.get(SOPHTRON_GET_JOB_INFO_PATH, () =>
+          HttpResponse.json({
+            JobID: testJobId,
+            JobType: "agg",
+            UserInstitutionID: testUserInstitutionId,
+          }),
+        ),
+      );
+
+      const response = await adapter.GetConnectionStatus(
+        testId,
+        testJobId,
+        false,
+        testUserId,
+      );
+
+      expect(response).toEqual({
+        id: testUserInstitutionId,
+        userId: testUserId,
+        cur_job_id: testJobId,
+        challenges: null,
+        postMessageEventData: createPostMessageEventData({
+          rawStatus: undefined,
+          selectedAccountId: "",
         }),
-      ),
-    );
-
-    const response = await adapter.GetConnectionStatus(
-      testId,
-      testJobId,
-      false,
-      testUserId,
-    );
-
-    expect(response).toEqual({
-      id: testUserInstitutionId,
-      userId: testUserId,
-      cur_job_id: testJobId,
-      challenges: null,
-      raw_status: undefined,
-      selected_account_id: '',
-      status: ConnectionStatus.CREATED,
-      aggregator: SOPHTRON_ADAPTER_NAME,
+        status: ConnectionStatus.CREATED,
+        aggregator: SOPHTRON_ADAPTER_NAME,
+      });
     });
   });
 

--- a/packages/sophtron-adapter/src/adapter.test.ts
+++ b/packages/sophtron-adapter/src/adapter.test.ts
@@ -514,7 +514,6 @@ describe("sophtron adapter", () => {
             JobType: "verification",
             LastStatus: accountsReadyStatus,
             UserInstitutionID: testUserInstitutionId,
-            AccounntId: "SAS_ACCOUNT_ID",
           }),
         ),
       );

--- a/packages/sophtron-adapter/src/adapter.ts
+++ b/packages/sophtron-adapter/src/adapter.ts
@@ -211,6 +211,10 @@ export class SophtronAdapter implements WidgetAdapter {
     } else if (job.SuccessFlag === false) {
       jobStatus = "failed";
     }
+    let sas_account = '';
+    if(job.AccountID && job.AccountID !== "00000000-0000-0000-0000-000000000000"){
+      sas_account = job.AccountID
+    }
     switch (jobStatus) {
       case "success":
         // case 'Completed':
@@ -223,8 +227,7 @@ export class SophtronAdapter implements WidgetAdapter {
         const jobType = job.JobType.toLowerCase();
         if (
           singleAccountSelect &&
-          (!job.AccountID ||
-            job.AccountID === "00000000-0000-0000-0000-000000000000") &&
+          !sas_account &&
           (jobType.indexOf("verification") >= 0 ||
             jobType.indexOf("verify") >= 0)
         ) {
@@ -251,6 +254,7 @@ export class SophtronAdapter implements WidgetAdapter {
           challenge.data = JSON.parse(job.SecurityQuestion).map(
             (q: string) => ({ key: q, value: q }),
           );
+          jobStatus = 'SecurityQuestion'
         } else if (job.TokenMethod) {
           challenge.id = "TokenMethod";
           challenge.type = ChallengeType.OPTIONS;
@@ -260,6 +264,7 @@ export class SophtronAdapter implements WidgetAdapter {
             key: q,
             value: q,
           }));
+          jobStatus = 'TokenMethod'
         } else if (job.TokenSentFlag === true) {
           challenge.id = "TokenInput";
           challenge.type = ChallengeType.QUESTION;
@@ -270,6 +275,7 @@ export class SophtronAdapter implements WidgetAdapter {
               value: `Please enter the ${job.TokenInputName || "OTA code"}`,
             },
           ];
+          jobStatus = 'TokenInput'
         } else if (job.TokenRead) {
           challenge.id = "TokenRead";
           challenge.type = ChallengeType.OPTIONS;
@@ -280,6 +286,7 @@ export class SophtronAdapter implements WidgetAdapter {
               value: "token_read",
             },
           ];
+          jobStatus = 'TokenRead'
         } else if (job.CaptchaImage) {
           challenge.id = "CaptchaImage";
           challenge.type = ChallengeType.IMAGE;
@@ -288,6 +295,7 @@ export class SophtronAdapter implements WidgetAdapter {
           // TODO: select captcha, currently it's combined into one image and treated as a normal Captcha Image
           // challenge.type = ChallengeType.IMAGE_OPTION
           // challenge.label = ''
+          jobStatus = 'CaptchaImage'
         } else {
           status = ConnectionStatus.CREATED;
         }
@@ -298,7 +306,9 @@ export class SophtronAdapter implements WidgetAdapter {
       userId: userId,
       cur_job_id: job.JobID,
       status,
-      challenges: challenge?.id ? [challenge] : undefined,
+      raw_status: jobStatus,
+      selected_account_id: sas_account,
+      challenges: challenge?.id ? [challenge] : null,
       aggregator: SOPHTRON_ADAPTER_NAME,
     };
   }

--- a/packages/sophtron-adapter/src/adapter.ts
+++ b/packages/sophtron-adapter/src/adapter.ts
@@ -211,9 +211,12 @@ export class SophtronAdapter implements WidgetAdapter {
     } else if (job.SuccessFlag === false) {
       jobStatus = "failed";
     }
-    let sas_account = '';
-    if(job.AccountID && job.AccountID !== "00000000-0000-0000-0000-000000000000"){
-      sas_account = job.AccountID
+    let sas_account = "";
+    if (
+      job.AccountID &&
+      job.AccountID !== "00000000-0000-0000-0000-000000000000"
+    ) {
+      sas_account = job.AccountID;
     }
     switch (jobStatus) {
       case "success":
@@ -254,7 +257,7 @@ export class SophtronAdapter implements WidgetAdapter {
           challenge.data = JSON.parse(job.SecurityQuestion).map(
             (q: string) => ({ key: q, value: q }),
           );
-          jobStatus = 'SecurityQuestion'
+          jobStatus = "SecurityQuestion";
         } else if (job.TokenMethod) {
           challenge.id = "TokenMethod";
           challenge.type = ChallengeType.OPTIONS;
@@ -264,7 +267,7 @@ export class SophtronAdapter implements WidgetAdapter {
             key: q,
             value: q,
           }));
-          jobStatus = 'TokenMethod'
+          jobStatus = "TokenMethod";
         } else if (job.TokenSentFlag === true) {
           challenge.id = "TokenInput";
           challenge.type = ChallengeType.QUESTION;
@@ -275,7 +278,7 @@ export class SophtronAdapter implements WidgetAdapter {
               value: `Please enter the ${job.TokenInputName || "OTA code"}`,
             },
           ];
-          jobStatus = 'TokenInput'
+          jobStatus = "TokenInput";
         } else if (job.TokenRead) {
           challenge.id = "TokenRead";
           challenge.type = ChallengeType.OPTIONS;
@@ -286,7 +289,7 @@ export class SophtronAdapter implements WidgetAdapter {
               value: "token_read",
             },
           ];
-          jobStatus = 'TokenRead'
+          jobStatus = "TokenRead";
         } else if (job.CaptchaImage) {
           challenge.id = "CaptchaImage";
           challenge.type = ChallengeType.IMAGE;
@@ -295,19 +298,27 @@ export class SophtronAdapter implements WidgetAdapter {
           // TODO: select captcha, currently it's combined into one image and treated as a normal Captcha Image
           // challenge.type = ChallengeType.IMAGE_OPTION
           // challenge.label = ''
-          jobStatus = 'CaptchaImage'
+          jobStatus = "CaptchaImage";
         } else {
           status = ConnectionStatus.CREATED;
         }
         break;
     }
+
+    const postMessageEventData = {
+      rawStatus: jobStatus,
+      selectedAccountId: sas_account,
+    };
+
     return {
       id: job.UserInstitutionID,
       userId: userId,
       cur_job_id: job.JobID,
+      postMessageEventData: {
+        memberConnected: postMessageEventData,
+        memberStatusUpdate: postMessageEventData,
+      },
       status,
-      raw_status: jobStatus,
-      selected_account_id: sas_account,
       challenges: challenge?.id ? [challenge] : null,
       aggregator: SOPHTRON_ADAPTER_NAME,
     };

--- a/packages/utils-dev-dependency/cypress/postMessageEvents.ts
+++ b/packages/utils-dev-dependency/cypress/postMessageEvents.ts
@@ -1,1 +1,2 @@
 export const MEMBER_CONNECTED_EVENT_TYPE = "connect/memberConnected";
+export const MEMBER_STATUS_UPDATE_EVENT_TYPE = "connect/memberStatusUpdate";

--- a/packages/utils/contract.ts
+++ b/packages/utils/contract.ts
@@ -145,6 +145,7 @@ export interface Connection {
   last_updated_utc?: string | null;
   background_aggregation_is_disabled?: boolean;
   status?: ConnectionStatus | null;
+  raw_status?: string | null;
   institution_code?: string | null;
   is_being_aggregated?: boolean | null;
   is_oauth?: boolean | null;
@@ -153,6 +154,7 @@ export interface Connection {
   userId?: string | null;
   challenges?: Challenge[];
   has_accounts?: boolean | null;
+  selected_account_id?: string | null;
   has_transactions?: boolean | null;
   is_authenticated?: boolean | null;
   vc?: string | null;

--- a/packages/utils/contract.ts
+++ b/packages/utils/contract.ts
@@ -137,6 +137,11 @@ export interface CreateConnectionRequest {
   metadata?: string;
 }
 
+export interface PostMessageEventData {
+  memberConnected?: object;
+  memberStatusUpdate?: object;
+}
+
 export interface Connection {
   id: string | null;
   cur_job_id?: string | null;
@@ -145,7 +150,6 @@ export interface Connection {
   last_updated_utc?: string | null;
   background_aggregation_is_disabled?: boolean;
   status?: ConnectionStatus | null;
-  raw_status?: string | null;
   institution_code?: string | null;
   is_being_aggregated?: boolean | null;
   is_oauth?: boolean | null;
@@ -154,12 +158,12 @@ export interface Connection {
   userId?: string | null;
   challenges?: Challenge[];
   has_accounts?: boolean | null;
-  selected_account_id?: string | null;
   has_transactions?: boolean | null;
   is_authenticated?: boolean | null;
   vc?: string | null;
   oauth_window_uri?: string | null;
   error_message?: string | null;
+  postMessageEventData?: PostMessageEventData;
 }
 
 export interface Connections {


### PR DESCRIPTION
added raw_status in connection object which will later made available through client side events, the raw_status field contains the status returned from aggregator before mapped to universal widget contract, this richer information enables client to track the connection status at a more detailed and accurate level which in turns provide the opportunity to trigger more process at a better timing, as well as make diagnosing easier

this is a feature currently used by our some clients to better track the connection progress and to better diagnose. 