### PR TITLE
Fix performance resilience for Sophtron

### DIFF
--- a/apps/server/src/aggregatorPerformanceMeasuring/utils.test.ts
+++ b/apps/server/src/aggregatorPerformanceMeasuring/utils.test.ts
@@ -27,6 +27,7 @@ describe("Performance Resilience", () => {
     connectionId: "test-connection-id",
     performanceSessionId: "test-session-id",
     aggregatorId: "mx",
+    jobId: "test-job-id",
   };
 
   beforeEach(() => {
@@ -382,6 +383,7 @@ describe("Performance Resilience", () => {
       connectionId: "test-connection-id",
       performanceSessionId: "test-session-id",
       aggregatorId: "mx",
+      jobId: "test-job-id",
     };
     let polledIds: string[];
 

--- a/apps/server/src/connect/connectApi.test.ts
+++ b/apps/server/src/connect/connectApi.test.ts
@@ -235,6 +235,7 @@ describe("connectApi", () => {
           connectionId: mxTestMemberData.member.guid,
           userId: resolvedUserId,
           aggregatorId: MX_AGGREGATOR_STRING,
+          jobId: mxTestMemberData.member.guid, // MX adapter returns the member guid as cur_job_id
           lastUiUpdateTimestamp: expect.any(Number),
           paused: false,
         }),

--- a/apps/server/src/connect/connectApi.ts
+++ b/apps/server/src/connect/connectApi.ts
@@ -223,6 +223,7 @@ export class ConnectApi extends AggregatorAdapterBase {
         connectionId: connection.id,
         performanceSessionId,
         aggregatorId: this.context.aggregator, // Must use the original aggregator string to request status from sandbox or prod adapters.
+        jobId: this.context.current_job_id,
       });
     }
     if (getConnectionCleanUpFeatureEnabled()) {


### PR DESCRIPTION
I noticed that the performance resilience keeps polling the sophtron status continuously but never gets an actual status in the response. I looks like Sophtron requires the jobId to be included in the request to get the latest status.